### PR TITLE
Enhance TypeScript documentation and expand error types reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -96,12 +96,14 @@
               "reference/index"
             ]
           },
-          {
-            "group": "TypeScript",
-            "pages": [
-              "reference/typescript/index"
-            ]
-          },
+           {
+             "group": "TypeScript",
+             "pages": [
+               "reference/typescript/index",
+               "reference/typescript/kit",
+               "reference/typescript/actions"
+             ]
+           },
           {
             "group": "Rust",
             "pages": [

--- a/reference/error-types/index.mdx
+++ b/reference/error-types/index.mdx
@@ -1,51 +1,361 @@
----
-title: "Program error types"
-description: "A comprehensive list of error types for the Swig Program, in hex and there meanings."
----
+# Swig Wallet Error Reference
 
-## Overview
+This document provides a comprehensive list of all error types used throughout the Swig wallet system, including their numeric codes and meanings.
 
-The Swig Program defines a set of error types to help developers diagnose issues that may arise during development. Each error type is represented as a hex value, with a corresponding human-readable description.
+For the complete source code and latest updates, see the [Swig Wallet repository](https://github.com/anagrambuild/swig-wallet).
 
-## Error Types related to State Management Operations
-| Error Type | Description                                      |
-| ---------- | ------------------------------------------------ |
-| 0x3E8      | Account data is invalid or corrupted             |
-| 0x3E9      | Action data is invalid or malformed              |
-| 0x3EA      | Authority data is invalid or malformed           |
-| 0x3EB      | Role data is invalid or malformed                |
-| 0x3EC      | Swig account data is invalid or malformed        |
-| 0x3ED      | Specified role could not be found                |
-| 0x3EE      | Error loading permissions                        |
-| 0x3EF      | Adding an authority requires at least one action |
+## Search Errors
 
-## Error Types related to Authentication Operations
-| Error Type | Description                                             |
-| ---------- | ------------------------------------------------------- |
-| 0xBB8      | Invalid authority provided                              |
-| 0xBB9      | Invalid authority payload format                        |
-| 0xBBA      | Invalid data payload format                             |
-| 0xBBB      | Missing Ed25519 authority account                       |
-| 0xBBC      | Authority does not support session-based authentication |
-| 0xBBD      | Generic permission denied error                         |
-| 0xBBE      | Missing required permission                             |
-| 0xBBF      | Token account permission check failed                   |
-| 0xBC0      | Token account has an active delegate or close authority |
-| 0xBC1      | Token account is not initialized                        |
-| 0xBC2      | No permission to manage authority                       |
-| 0xBC3      | Insufficient balance for operation                      |
-| 0xBC4      | Cannot remove root authority                            |
-| 0xBC5      | Session has expired                                     |
-| 0xBC6      | Invalid Secp256k1 signature                             |
-| 0xBC7      | Secp256k1 signature age is invalid                      |
-| 0xBC8      | Secp256k1 signature has been reused                     |
-| 0xBC9      | Invalid Secp256k1 hash                                  |
-| 0xBCA      | Secp256r1 signature has been reused                     |
-| 0xBCB      | Stake account is in an invalid state                    |
-| 0xBCC      | Cannot reuse session key                                |
-| 0xBCD      | Invalid session duration                                |
-| 0xBCE      | Token account authority is not the Swig account         |
-| 0xBCF      | Invalid Secp256r1 instruction                           |
-| 0xBD0      | Invalid Secp256r1 public key                            |
-| 0xBD1      | Invalid Secp256r1 message hash                          |
-| 0xBD2      | Invalid Secp256r1 message                               |
+<div style={{position: "relative", marginBottom: "20px"}}>
+  <input
+    type="text"
+    placeholder="Search errors by code, name, or description..."
+    style={{
+      width: "100%",
+      padding: "10px",
+      fontSize: "16px",
+      border: "1px solid #ccc",
+      borderRadius: "4px"
+    }}
+    onChange={(e) => {
+      const searchTerm = e.target.value.toLowerCase().trim();
+      const resultsDiv = document.getElementById('searchResults');
+      
+      if (!searchTerm) {
+        resultsDiv.style.display = 'none';
+        return;
+      }
+      
+      // Detect theme mode from localStorage first, then fallback to other methods
+      let isDark = false;
+      
+      try {
+        const storedTheme = localStorage.getItem('theme') || localStorage.getItem('isDarkMode');
+        if (storedTheme) {
+          isDark = storedTheme === 'dark' || storedTheme === 'true';
+        } else {
+          // Fallback to DOM classes and system preference
+          isDark = document.documentElement.classList.contains('dark') || 
+                   document.body.classList.contains('dark') ||
+                   window.matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+      } catch (e) {
+        // Fallback if localStorage is not available
+        isDark = document.documentElement.classList.contains('dark') || 
+                 document.body.classList.contains('dark') ||
+                 window.matchMedia('(prefers-color-scheme: dark)').matches;
+      }
+      
+      const theme = {
+        bg: isDark ? '#000' : '#fff',
+        border: isDark ? '#333' : '#ccc',
+        text: isDark ? '#fff' : '#333',
+        textSecondary: isDark ? '#ccc' : '#666',
+        textTertiary: isDark ? '#999' : '#999',
+        codeColor: isDark ? '#66b3ff' : '#0066cc',
+        hoverBg: isDark ? '#333' : '#f5f5f5',
+        noResultsColor: isDark ? '#ccc' : '#666'
+      };
+      
+      // Update results div styling
+      Object.assign(resultsDiv.style, {
+        backgroundColor: theme.bg,
+        border: `1px solid ${theme.border}`,
+        boxShadow: isDark ? '0 4px 6px rgba(0,0,0,0.3)' : '0 4px 6px rgba(0,0,0,0.1)'
+      });
+      
+      // Error data for searching
+      const errors = [
+        // State Errors
+        { code: "1000 (0x3E8)", name: "InvalidAccountData", desc: "Account data is invalid or corrupted", category: "State" },
+        { code: "1001 (0x3E9)", name: "InvalidActionData", desc: "Action data is invalid or malformed", category: "State" },
+        { code: "1002 (0x3EA)", name: "InvalidAuthorityData", desc: "Authority data is invalid or malformed", category: "State" },
+        { code: "1003 (0x3EB)", name: "InvalidRoleData", desc: "Role data is invalid or malformed", category: "State" },
+        { code: "1004 (0x3EC)", name: "InvalidSwigData", desc: "Swig account data is invalid or malformed", category: "State" },
+        { code: "1005 (0x3ED)", name: "RoleNotFound", desc: "Specified role could not be found", category: "State" },
+        { code: "1006 (0x3EE)", name: "PermissionLoadError", desc: "Error loading permissions", category: "State" },
+        { code: "1007 (0x3EF)", name: "InvalidAuthorityMustHaveAtLeastOneAction", desc: "Adding an authority requires at least one action", category: "State" },
+        
+        // Authentication Errors
+        { code: "3000 (0xBB8)", name: "InvalidAuthority", desc: "Invalid authority provided", category: "Authentication" },
+        { code: "3001 (0xBB9)", name: "InvalidAuthorityPayload", desc: "Invalid authority payload format", category: "Authentication" },
+        { code: "3002 (0xBBA)", name: "InvalidDataPayload", desc: "Invalid data payload format", category: "Authentication" },
+        { code: "3003 (0xBBB)", name: "InvalidAuthorityEd25519MissingAuthorityAccount", desc: "Missing Ed25519 authority account", category: "Authentication" },
+        { code: "3004 (0xBBC)", name: "AuthorityDoesNotSupportSessionBasedAuth", desc: "Authority does not support session-based authentication", category: "Authentication" },
+        { code: "3005 (0xBBD)", name: "PermissionDenied", desc: "Generic permission denied error", category: "Authentication" },
+        { code: "3006 (0xBBE)", name: "PermissionDeniedMissingPermission", desc: "Missing required permission", category: "Authentication" },
+        { code: "3007 (0xBBF)", name: "PermissionDeniedTokenAccountPermissionFailure", desc: "Token account permission check failed", category: "Authentication" },
+        { code: "3008 (0xBC0)", name: "PermissionDeniedTokenAccountDelegatePresent", desc: "Token account has an active delegate or close authority", category: "Authentication" },
+        { code: "3009 (0xBC1)", name: "PermissionDeniedTokenAccountNotInitialized", desc: "Token account is not initialized", category: "Authentication" },
+        { code: "3010 (0xBC2)", name: "PermissionDeniedToManageAuthority", desc: "No permission to manage authority", category: "Authentication" },
+        { code: "3011 (0xBC3)", name: "PermissionDeniedInsufficientBalance", desc: "Insufficient balance for operation", category: "Authentication" },
+        { code: "3012 (0xBC4)", name: "PermissionDeniedCannotRemoveRootAuthority", desc: "Cannot remove root authority", category: "Authentication" },
+        { code: "3013 (0xBC5)", name: "PermissionDeniedCannotUpdateRootAuthority", desc: "Cannot update root authority", category: "Authentication" },
+        { code: "3014 (0xBC6)", name: "PermissionDeniedSessionExpired", desc: "Session has expired", category: "Authentication" },
+        { code: "3015 (0xBC7)", name: "PermissionDeniedSecp256k1InvalidSignature", desc: "Invalid Secp256k1 signature", category: "Authentication" },
+        { code: "3016 (0xBC8)", name: "PermissionDeniedSecp256k1InvalidSignatureAge", desc: "Secp256k1 signature age is invalid", category: "Authentication" },
+        { code: "3017 (0xBC9)", name: "PermissionDeniedSecp256k1SignatureReused", desc: "Secp256k1 signature has been reused", category: "Authentication" },
+        { code: "3018 (0xBCA)", name: "PermissionDeniedSecp256k1InvalidHash", desc: "Invalid Secp256k1 hash", category: "Authentication" },
+        { code: "3019 (0xBCB)", name: "PermissionDeniedSecp256r1SignatureReused", desc: "Secp256r1 signature has been reused", category: "Authentication" },
+        { code: "3020 (0xBCC)", name: "PermissionDeniedStakeAccountInvalidState", desc: "Stake account is in an invalid state", category: "Authentication" },
+        { code: "3021 (0xBCD)", name: "InvalidSessionKeyCannotReuseSessionKey", desc: "Cannot reuse session key", category: "Authentication" },
+        { code: "3022 (0xBCE)", name: "InvalidSessionDuration", desc: "Invalid session duration", category: "Authentication" },
+        { code: "3023 (0xBCF)", name: "PermissionDeniedTokenAccountAuthorityNotSwig", desc: "Token account authority is not the Swig account", category: "Authentication" },
+        { code: "3024 (0xBD0)", name: "PermissionDeniedSecp256r1InvalidInstruction", desc: "Invalid Secp256r1 instruction", category: "Authentication" },
+        { code: "3025 (0xBD1)", name: "PermissionDeniedSecp256r1InvalidPubkey", desc: "Invalid Secp256r1 public key", category: "Authentication" },
+        { code: "3026 (0xBD2)", name: "PermissionDeniedSecp256r1InvalidMessageHash", desc: "Invalid Secp256r1 message hash", category: "Authentication" },
+        { code: "3027 (0xBD3)", name: "PermissionDeniedSecp256r1InvalidMessage", desc: "Invalid Secp256r1 message", category: "Authentication" },
+        { code: "3028 (0xBD4)", name: "PermissionDeniedSecp256r1InvalidAuthenticationKind", desc: "Invalid Secp256r1 authentication kind", category: "Authentication" },
+        { code: "3029 (0xBD5)", name: "PermissionDeniedSolDestinationLimitExceeded", desc: "SOL destination limit exceeded", category: "Authentication" },
+        { code: "3030 (0xBD6)", name: "PermissionDeniedSolDestinationRecurringLimitExceeded", desc: "SOL destination recurring limit exceeded", category: "Authentication" },
+        { code: "3031 (0xBD7)", name: "PermissionDeniedTokenDestinationLimitExceeded", desc: "Token destination limit exceeded", category: "Authentication" },
+        { code: "3032 (0xBD8)", name: "PermissionDeniedRecurringTokenDestinationLimitExceeded", desc: "Token destination recurring limit exceeded", category: "Authentication" },
+        
+        // Program Errors
+        { code: "0 (0x0)", name: "InvalidSwigAccountDiscriminator", desc: "Invalid discriminator in Swig account data", category: "Program" },
+        { code: "1 (0x1)", name: "OwnerMismatchSwigAccount", desc: "Swig account owner does not match expected value", category: "Program" },
+        { code: "2 (0x2)", name: "AccountNotEmptySwigAccount", desc: "Swig account is not empty when it should be", category: "Program" },
+        { code: "3 (0x3)", name: "NotOnCurveSwigAccount", desc: "Public key in Swig account is not on the curve", category: "Program" },
+        { code: "4 (0x4)", name: "ExpectedSignerSwigAccount", desc: "Expected Swig account to be a signer but it isn't", category: "Program" },
+        { code: "5 (0x5)", name: "StateError", desc: "General state error in program execution", category: "Program" },
+        { code: "6 (0x6)", name: "AccountBorrowFailed", desc: "Failed to borrow account data", category: "Program" },
+        { code: "7 (0x7)", name: "InvalidAuthorityType", desc: "Invalid authority type specified", category: "Program" },
+        { code: "8 (0x8)", name: "Cpi", desc: "Error during cross-program invocation", category: "Program" },
+        { code: "9 (0x9)", name: "InvalidSeedSwigAccount", desc: "Invalid seed used for Swig account derivation", category: "Program" },
+        { code: "10 (0xA)", name: "MissingInstructions", desc: "Required instructions are missing", category: "Program" },
+        
+        // Instruction Errors
+        { code: "2000 (0x7D0)", name: "MissingInstructions", desc: "No instructions found in the instruction data", category: "Instruction" },
+        { code: "2001 (0x7D1)", name: "MissingAccountInfo", desc: "Required account info not found at specified index", category: "Instruction" },
+        { code: "2002 (0x7D2)", name: "MissingData", desc: "Instruction data is incomplete or invalid", category: "Instruction" }
+      ];
+      
+      const matches = errors.filter(error => 
+        error.code.toLowerCase().includes(searchTerm) ||
+        error.name.toLowerCase().includes(searchTerm) ||
+        error.desc.toLowerCase().includes(searchTerm) ||
+        error.category.toLowerCase().includes(searchTerm)
+      );
+      
+      if (matches.length === 0) {
+        resultsDiv.innerHTML = `<div style="padding: 10px; color: ${theme.noResultsColor};">No matching errors found</div>`;
+      } else {
+        resultsDiv.innerHTML = matches.slice(0, 10).map(error => `
+          <div style="padding: 10px; border-bottom: 1px solid ${theme.border}; cursor: pointer; transition: background-color 0.2s;" 
+               onclick="this.parentElement.style.display='none'"
+               onmouseover="this.style.backgroundColor='${theme.hoverBg}'"
+               onmouseout="this.style.backgroundColor='transparent'">
+            <div style="font-weight: bold; color: ${theme.text};">
+              <span style="color: ${theme.codeColor};">${error.code}</span> - ${error.name}
+            </div>
+            <div style="font-size: 14px; color: ${theme.textSecondary}; margin-top: 4px;">
+              ${error.desc}
+            </div>
+            <div style="font-size: 12px; color: ${theme.textTertiary}; margin-top: 4px;">
+              Category: ${error.category}
+            </div>
+          </div>
+        `).join('');
+        
+        if (matches.length > 10) {
+          resultsDiv.innerHTML += `<div style="padding: 10px; color: ${theme.textSecondary}; font-style: italic;">... and ${matches.length - 10} more results</div>`;
+        }
+      }
+      
+      resultsDiv.style.display = 'block';
+    }}
+  />
+  <div 
+    id="searchResults"
+    style={{
+      display: "none",
+      position: "absolute",
+      top: "100%",
+      left: "0",
+      right: "0",
+      borderTop: "none",
+      borderRadius: "0 0 4px 4px",
+      maxHeight: "400px",
+      overflowY: "auto",
+      zIndex: 1000
+    }}
+  />
+</div>
+
+## Error Code Ranges
+
+- **1000-1999**: State errors (`swig_state::SwigStateError`)
+- **2000-2999**: Instruction processing errors (`swig_instructions::InstructionError`)
+- **3000-3999**: Authentication errors (`swig_state::SwigAuthenticateError`)
+- **0-999**: Program errors (`swig_program::SwigError`)
+
+## State Errors (`swig_state::SwigStateError`)
+
+Located in: [`state/src/lib.rs:91-108`](https://github.com/anagrambuild/swig-wallet/blob/main/state/src/lib.rs#L91-L108)
+
+These errors are related to state management operations and data validation.
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 1000 (0x3E8) | `InvalidAccountData` | Account data is invalid or corrupted |
+| 1001 (0x3E9) | `InvalidActionData` | Action data is invalid or malformed |
+| 1002 (0x3EA) | `InvalidAuthorityData` | Authority data is invalid or malformed |
+| 1003 (0x3EB) | `InvalidRoleData` | Role data is invalid or malformed |
+| 1004 (0x3EC) | `InvalidSwigData` | Swig account data is invalid or malformed |
+| 1005 (0x3ED) | `RoleNotFound` | Specified role could not be found |
+| 1006 (0x3EE) | `PermissionLoadError` | Error loading permissions |
+| 1007 (0x3EF) | `InvalidAuthorityMustHaveAtLeastOneAction` | Adding an authority requires at least one action |
+
+## Authentication Errors (`swig_state::SwigAuthenticateError`)
+
+Located in: [`state/src/lib.rs:111-178`](https://github.com/anagrambuild/swig-wallet/blob/main/state/src/lib.rs#L111-L178)
+
+These errors are related to authentication operations and permission validation.
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 3000 (0xBB8) | `InvalidAuthority` | Invalid authority provided |
+| 3001 (0xBB9) | `InvalidAuthorityPayload` | Invalid authority payload format |
+| 3002 (0xBBA) | `InvalidDataPayload` | Invalid data payload format |
+| 3003 (0xBBB) | `InvalidAuthorityEd25519MissingAuthorityAccount` | Missing Ed25519 authority account |
+| 3004 (0xBBC) | `AuthorityDoesNotSupportSessionBasedAuth` | Authority does not support session-based authentication |
+| 3005 (0xBBD) | `PermissionDenied` | Generic permission denied error |
+| 3006 (0xBBE) | `PermissionDeniedMissingPermission` | Missing required permission |
+| 3007 (0xBBF) | `PermissionDeniedTokenAccountPermissionFailure` | Token account permission check failed |
+| 3008 (0xBC0) | `PermissionDeniedTokenAccountDelegatePresent` | Token account has an active delegate or close authority |
+| 3009 (0xBC1) | `PermissionDeniedTokenAccountNotInitialized` | Token account is not initialized |
+| 3010 (0xBC2) | `PermissionDeniedToManageAuthority` | No permission to manage authority |
+| 3011 (0xBC3) | `PermissionDeniedInsufficientBalance` | Insufficient balance for operation |
+| 3012 (0xBC4) | `PermissionDeniedCannotRemoveRootAuthority` | Cannot remove root authority |
+| 3013 (0xBC5) | `PermissionDeniedCannotUpdateRootAuthority` | Cannot update root authority |
+| 3014 (0xBC6) | `PermissionDeniedSessionExpired` | Session has expired |
+| 3015 (0xBC7) | `PermissionDeniedSecp256k1InvalidSignature` | Invalid Secp256k1 signature |
+| 3016 (0xBC8) | `PermissionDeniedSecp256k1InvalidSignatureAge` | Secp256k1 signature age is invalid |
+| 3017 (0xBC9) | `PermissionDeniedSecp256k1SignatureReused` | Secp256k1 signature has been reused |
+| 3018 (0xBCA) | `PermissionDeniedSecp256k1InvalidHash` | Invalid Secp256k1 hash |
+| 3019 (0xBCB) | `PermissionDeniedSecp256r1SignatureReused` | Secp256r1 signature has been reused |
+| 3020 (0xBCC) | `PermissionDeniedStakeAccountInvalidState` | Stake account is in an invalid state |
+| 3021 (0xBCD) | `InvalidSessionKeyCannotReuseSessionKey` | Cannot reuse session key |
+| 3022 (0xBCE) | `InvalidSessionDuration` | Invalid session duration |
+| 3023 (0xBCF) | `PermissionDeniedTokenAccountAuthorityNotSwig` | Token account authority is not the Swig account |
+| 3024 (0xBD0) | `PermissionDeniedSecp256r1InvalidInstruction` | Invalid Secp256r1 instruction |
+| 3025 (0xBD1) | `PermissionDeniedSecp256r1InvalidPubkey` | Invalid Secp256r1 public key |
+| 3026 (0xBD2) | `PermissionDeniedSecp256r1InvalidMessageHash` | Invalid Secp256r1 message hash |
+| 3027 (0xBD3) | `PermissionDeniedSecp256r1InvalidMessage` | Invalid Secp256r1 message |
+| 3028 (0xBD4) | `PermissionDeniedSecp256r1InvalidAuthenticationKind` | Invalid Secp256r1 authentication kind |
+| 3029 (0xBD5) | `PermissionDeniedSolDestinationLimitExceeded` | SOL destination limit exceeded |
+| 3030 (0xBD6) | `PermissionDeniedSolDestinationRecurringLimitExceeded` | SOL destination recurring limit exceeded |
+| 3031 (0xBD7) | `PermissionDeniedTokenDestinationLimitExceeded` | Token destination limit exceeded |
+| 3032 (0xBD8) | `PermissionDeniedRecurringTokenDestinationLimitExceeded` | Token destination recurring limit exceeded |
+
+## Program Errors (`swig_program::SwigError`)
+
+Located in: [`program/src/error.rs:20-115`](https://github.com/anagrambuild/swig-wallet/blob/main/program/src/error.rs#L20-L115)
+
+These errors can occur during program execution and are categorized by functionality.
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 0 (0x0) | `InvalidSwigAccountDiscriminator` | Invalid discriminator in Swig account data |
+| 1 (0x1) | `OwnerMismatchSwigAccount` | Swig account owner does not match expected value |
+| 2 (0x2) | `AccountNotEmptySwigAccount` | Swig account is not empty when it should be |
+| 3 (0x3) | `NotOnCurveSwigAccount` | Public key in Swig account is not on the curve |
+| 4 (0x4) | `ExpectedSignerSwigAccount` | Expected Swig account to be a signer but it isn't |
+| 5 (0x5) | `StateError` | General state error in program execution |
+| 6 (0x6) | `AccountBorrowFailed` | Failed to borrow account data |
+| 7 (0x7) | `InvalidAuthorityType` | Invalid authority type specified |
+| 8 (0x8) | `Cpi` | Error during cross-program invocation |
+| 9 (0x9) | `InvalidSeedSwigAccount` | Invalid seed used for Swig account derivation |
+| 10 (0xA) | `MissingInstructions` | Required instructions are missing |
+| 11 (0xB) | `InvalidAuthorityPayload` | Invalid authority payload format |
+| 12 (0xC) | `InvalidAuthorityNotFoundByRoleId` | Authority not found for given role ID |
+| 13 (0xD) | `InvalidAuthorityMustHaveAtLeastOneAction` | Authority must have at least one action |
+| 14 (0xE) | `InstructionExecutionError` | Error during instruction execution |
+| 15 (0xF) | `SerializationError` | Error during data serialization |
+| 16 (0x10) | `InvalidSwigSignInstructionDataTooShort` | Sign instruction data is too short |
+| 17 (0x11) | `InvalidSwigRemoveAuthorityInstructionDataTooShort` | Remove authority instruction data is too short |
+| 18 (0x12) | `InvalidSwigAddAuthorityInstructionDataTooShort` | Add authority instruction data is too short |
+| 19 (0x13) | `InvalidSwigUpdateAuthorityInstructionDataTooShort` | Update authority instruction data is too short |
+| 20 (0x14) | `InvalidSwigCreateInstructionDataTooShort` | Create instruction data is too short |
+| 21 (0x15) | `InvalidSwigCreateSessionInstructionDataTooShort` | Create session instruction data is too short |
+| 22 (0x16) | `InvalidAccountsLength` | Invalid number of accounts provided |
+| 23 (0x17) | `InvalidAccountsSwigMustBeFirst` | Swig account must be the first account in the list |
+| 24 (0x18) | `InvalidSystemProgram` | Invalid system program account |
+| 25 (0x19) | `DuplicateAuthority` | Authority already exists |
+| 26 (0x1A) | `InvalidOperation` | Invalid operation attempted |
+| 27 (0x1B) | `InvalidAlignment` | Data alignment error |
+| 28 (0x1C) | `InvalidSeedSubAccount` | Invalid seed used for sub-account derivation |
+| 29 (0x1D) | `InsufficientFunds` | Insufficient funds for operation |
+| 30 (0x1E) | `OwnerMismatchTokenAccount` | Token account owner mismatch |
+| 31 (0x1F) | `PermissionDenied` | Permission denied for operation |
+| 32 (0x20) | `InvalidSignature` | Invalid signature provided |
+| 33 (0x21) | `InvalidInstructionDataTooShort` | Instruction data is too short |
+| 34 (0x22) | `OwnerMismatchSubAccount` | Sub-account owner mismatch |
+| 35 (0x23) | `SubAccountAlreadyExists` | Sub-account already exists |
+| 36 (0x24) | `AuthorityCannotCreateSubAccount` | Authority cannot create sub-account |
+| 37 (0x25) | `InvalidSwigSubAccountDiscriminator` | Invalid discriminator in sub-account data |
+| 38 (0x26) | `InvalidSwigSubAccountDisabled` | Sub-account is disabled |
+| 39 (0x27) | `InvalidSwigSubAccountSwigIdMismatch` | Sub-account Swig ID mismatch |
+| 40 (0x28) | `InvalidSwigSubAccountRoleIdMismatch` | Sub-account role ID mismatch |
+| 41 (0x29) | `InvalidSwigTokenAccountOwner` | Invalid token account owner |
+| 42 (0x2A) | `InvalidProgramScopeBalanceFields` | Invalid program scope balance field configuration |
+| 43 (0x2B) | `AccountDataModifiedUnexpectedly` | Account data was modified in unexpected ways during instruction execution |
+| 44 (0x2C) | `PermissionDeniedCannotUpdateRootAuthority` | Cannot update root authority (ID 0) |
+
+## Instruction Processing Errors (`swig_instructions::InstructionError`)
+
+Located in: [`instructions/src/lib.rs:25-32`](https://github.com/anagrambuild/swig-wallet/blob/main/instructions/src/lib.rs#L25-L32)
+
+These errors can occur during instruction processing and parsing.
+
+| Code | Error | Description |
+|------|-------|-------------|
+| 2000 (0x7D0) | `MissingInstructions` | No instructions found in the instruction data |
+| 2001 (0x7D1) | `MissingAccountInfo` | Required account info not found at specified index |
+| 2002 (0x7D2) | `MissingData` | Instruction data is incomplete or invalid |
+
+## SDK Errors (`rust_sdk::SwigError`)
+
+Located in: [`rust-sdk/src/error.rs:4-80`](https://github.com/anagrambuild/swig-wallet/blob/main/rust-sdk/src/error.rs#L4-L80)
+
+These errors occur in the Rust SDK when interacting with the Swig wallet system.
+
+| Error | Description |
+|-------|-------------|
+| `InvalidAuthorityType` | Indicates that an invalid authority type was provided |
+| `Base58DecodeError` | Error occurred during base58 decoding |
+| `ProgramError` | Solana program error |
+| `InterfaceError` | General interface error with description |
+| `ClientError` | RPC client error |
+| `InvalidSwigData` | Invalid swig data |
+| `AuthorityNotFound` | Authority not found |
+| `InvalidSwigAccountDiscriminator` | Invalid swig account discriminator |
+| `MessageCompilationError` | Error occurred during message compilation |
+| `InvalidSecp256k1` | Invalid secp256k1 signature |
+| `TransactionError` | Transaction error |
+| `CurrentSlotNotSet` | Current slot not set |
+| `SwigDataNotFound` | Swig data not found |
+| `TransactionFailed` | Transaction failed |
+| `TransactionCreationFailed` | Transaction creation failed |
+| `TransactionCompilationFailed` | Transaction compilation failed |
+| `TransactionFailedWithLogs` | Transaction failed with logs |
+| `InvalidProgramScope` | Invalid program scope |
+| `CounterNotSet` | Counter not set |
+
+## Common Error Patterns
+
+### Permission-Related Errors
+
+Most permission errors start with `PermissionDenied` and are in the 3000+ range. These indicate various authorization failures.
+
+### Data Validation Errors
+
+Errors starting with `Invalid` typically indicate malformed or invalid data structures.
+
+### Account-Related Errors
+
+Errors containing `Account` in the name relate to account validation, ownership, or state issues.
+
+### Signature-Related Errors
+
+Errors containing `Signature` or cryptographic scheme names (like `Secp256k1`, `Secp256r1`) relate to signature validation failures.

--- a/reference/typescript/actions.mdx
+++ b/reference/typescript/actions.mdx
@@ -1,0 +1,636 @@
+# Swig Actions Documentation
+
+This document provides comprehensive documentation for all available Swig Actions, including their inputs, outputs, and usage examples.
+
+## Overview
+
+Swig Actions define permissions and spending limits for authorities in the Swig wallet system. Actions are composed using a builder pattern starting with `Actions.set()` and ending with `.get()`.
+
+```typescript
+const actions = Actions.set()
+  .tokenDestinationLimit({
+    mint: mintKeypair.publicKey,
+    amount: tokenLimitAmount,
+    destination: recipientAta,
+  })
+  .get();
+```
+
+## Action Categories
+
+### 1. Root/Management Actions
+
+#### `all()`
+
+Grants unlimited permissions for all operations.
+
+**Inputs:** None  
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const rootActions = Actions.set().all().get();
+```
+
+**Permissions Granted:**
+- Unlimited SOL and token spending
+- Access to all programs
+- Authority management
+- All other operations
+
+---
+
+#### `manageAuthority()`
+
+Grants permission to manage authorities (add/remove authorities).
+
+**Inputs:** None  
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const manageActions = Actions.set().manageAuthority().get();
+```
+
+**Permissions Granted:**
+- Add new authorities
+- Remove existing authorities
+
+---
+
+#### `allButManageAuthority()`
+
+Grants all permissions except authority management.
+
+**Inputs:** None  
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const limitedRootActions = Actions.set().allButManageAuthority().get();
+```
+
+**Permissions Granted:**
+- Unlimited SOL and token spending
+- Access to all programs
+- All operations except authority management
+
+---
+
+### 2. Program Actions
+
+#### `programLimit(payload)`
+
+Grants permission to interact with a specific program.
+
+**Inputs:**
+- `payload.programId: SolPublicKeyData` - The program ID to allow access to
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const programActions = Actions.set()
+  .programLimit({ programId: 'SystemProgram11111111111111111111111111111' })
+  .get();
+```
+
+**Permissions Granted:**
+- Execute transactions with the specified program
+
+---
+
+#### `programAll()`
+
+Grants permission to interact with all programs.
+
+**Inputs:** None  
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const allProgramActions = Actions.set().programAll().get();
+```
+
+**Permissions Granted:**
+- Execute transactions with any program
+
+---
+
+#### `programCurated()`
+
+Grants permission to interact with curated/whitelisted programs.
+
+**Inputs:** None  
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const curatedActions = Actions.set().programCurated().get();
+```
+
+**Permissions Granted:**
+- Execute transactions with approved/curated programs
+
+---
+
+#### `programScopeBasic(payload)`
+
+Basic program scope with specific target account.
+
+**Inputs:**
+- `payload.programId: SolPublicKeyData` - Program ID
+- `payload.targetAccount: SolPublicKeyData` - Target account within the program
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const basicScopeActions = Actions.set()
+  .programScopeBasic({
+    programId: 'TokenProgramId',
+    targetAccount: 'TokenAccountAddress',
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Access to specific program with targeted account interactions
+
+---
+
+#### `programScopeLimit(payload)`
+
+Program scope with spending limits.
+
+**Inputs:**
+- `payload.programId: SolPublicKeyData` - Program ID
+- `payload.targetAccount: SolPublicKeyData` - Target account
+- `payload.amount: bigint` - Maximum spendable amount
+- `payload.numericType: NumericType` - Numeric type (U8, U32, U64, U128)
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+import { NumericType } from '@swig-wallet/coder';
+
+const limitedScopeActions = Actions.set()
+  .programScopeLimit({
+    programId: 'TokenProgramId',
+    targetAccount: 'TokenAccountAddress',
+    amount: 1000n,
+    numericType: NumericType.U64,
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Limited access to specific program with amount restrictions
+
+---
+
+#### `programScopeRecurringLimit(payload)`
+
+Program scope with recurring spending limits.
+
+**Inputs:**
+- `payload.programId: SolPublicKeyData` - Program ID
+- `payload.targetAccount: SolPublicKeyData` - Target account
+- `payload.amount: bigint` - Recurring amount limit
+- `payload.window: bigint` - Time window in slots for limit reset
+- `payload.numericType: NumericType` - Numeric type (U8, U32, U64, U128)
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const recurringLimitActions = Actions.set()
+  .programScopeRecurringLimit({
+    programId: 'TokenProgramId',
+    targetAccount: 'TokenAccountAddress',
+    amount: 1000n,
+    window: 1000n, // slots
+    numericType: NumericType.U64,
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Recurring limited access to specific program
+
+---
+
+### 3. SOL Spending Actions
+
+#### `solLimit(payload)`
+
+One-time SOL spending limit.
+
+**Inputs:**
+- `payload.amount: bigint` - Maximum SOL amount to spend (in lamports)
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const solActions = Actions.set()
+  .solLimit({ amount: 1000000000n }) // 1 SOL in lamports
+  .get();
+```
+
+**Permissions Granted:**
+- Spend up to the specified amount of SOL once
+
+---
+
+#### `solRecurringLimit(payload)`
+
+Recurring SOL spending limit.
+
+**Inputs:**
+- `payload.recurringAmount: bigint` - SOL amount per window (in lamports)
+- `payload.window: bigint` - Time window in slots until reset
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const recurringActions = Actions.set()
+  .solRecurringLimit({
+    recurringAmount: 500000000n, // 0.5 SOL per window
+    window: 100000n, // slots
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Spend up to the specified amount of SOL per time window
+
+---
+
+#### `solDestinationLimit(payload)`
+
+One-time SOL spending to a specific destination.
+
+**Inputs:**
+- `payload.amount: bigint` - SOL amount (in lamports)
+- `payload.destination: SolPublicKeyData` - Destination public key
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const destinationActions = Actions.set()
+  .solDestinationLimit({
+    amount: 2000000000n, // 2 SOL
+    destination: 'RecipientPublicKey',
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Send up to the specified SOL amount to the specified destination once
+
+---
+
+#### `solRecurringDestinationLimit(payload)`
+
+Recurring SOL spending to a specific destination.
+
+**Inputs:**
+- `payload.recurringAmount: bigint` - SOL amount per window (in lamports)
+- `payload.window: bigint` - Time window in slots until reset
+- `payload.destination: SolPublicKeyData` - Destination public key
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const recurringDestActions = Actions.set()
+  .solRecurringDestinationLimit({
+    recurringAmount: 1000000000n, // 1 SOL per window
+    window: 86400n, // slots (approximately 1 day)
+    destination: 'RecipientPublicKey',
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Send up to the specified SOL amount to the destination per time window
+
+---
+
+### 4. Token Spending Actions
+
+#### `tokenLimit(payload)`
+
+One-time token spending limit.
+
+**Inputs:**
+- `payload.mint: SolPublicKeyData` - Token mint public key
+- `payload.amount: bigint` - Maximum token amount to spend
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const tokenActions = Actions.set()
+  .tokenLimit({
+    mint: 'USDCMintPublicKey',
+    amount: 1000000n, // 1 USDC (6 decimals)
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Spend up to the specified amount of the token once
+
+---
+
+#### `tokenRecurringLimit(payload)`
+
+Recurring token spending limit.
+
+**Inputs:**
+- `payload.mint: SolPublicKeyData` - Token mint public key
+- `payload.recurringAmount: bigint` - Token amount per window
+- `payload.window: bigint` - Time window in slots until reset
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const recurringTokenActions = Actions.set()
+  .tokenRecurringLimit({
+    mint: 'USDCMintPublicKey',
+    recurringAmount: 500000n, // 0.5 USDC per window
+    window: 50000n, // slots
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Spend up to the specified token amount per time window
+
+---
+
+#### `tokenDestinationLimit(payload)`
+
+One-time token spending to a specific destination.
+
+**Inputs:**
+- `payload.mint: SolPublicKeyData` - Token mint public key
+- `payload.amount: bigint` - Token amount
+- `payload.destination: SolPublicKeyData` - Destination public key
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const tokenDestActions = Actions.set()
+  .tokenDestinationLimit({
+    mint: 'USDCMintPublicKey',
+    amount: 2000000n, // 2 USDC
+    destination: 'RecipientTokenAccount',
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Send up to the specified token amount to the destination once
+
+---
+
+#### `tokenRecurringDestinationLimit(payload)`
+
+Recurring token spending to a specific destination.
+
+**Inputs:**
+- `payload.mint: SolPublicKeyData` - Token mint public key
+- `payload.recurringAmount: bigint` - Token amount per window
+- `payload.window: bigint` - Time window in slots until reset
+- `payload.destination: SolPublicKeyData` - Destination public key
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const recurringTokenDestActions = Actions.set()
+  .tokenRecurringDestinationLimit({
+    mint: 'USDCMintPublicKey',
+    recurringAmount: 1000000n, // 1 USDC per window
+    window: 86400n, // slots
+    destination: 'RecipientTokenAccount',
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Send up to the specified token amount to the destination per time window
+
+---
+
+### 5. Staking Actions
+
+#### `stakeAll()`
+
+Unlimited staking permissions.
+
+**Inputs:** None  
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const stakeActions = Actions.set().stakeAll().get();
+```
+
+**Permissions Granted:**
+- Unlimited staking operations
+
+---
+
+#### `stakeLimit(payload)`
+
+One-time staking limit.
+
+**Inputs:**
+- `payload.amount: bigint` - Maximum stake amount
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const stakeLimitActions = Actions.set()
+  .stakeLimit({ amount: 5000000000n }) // 5 SOL
+  .get();
+```
+
+**Permissions Granted:**
+- Stake up to the specified amount once
+
+---
+
+#### `stakeRecurringLimit(payload)`
+
+Recurring staking limit.
+
+**Inputs:**
+- `payload.recurringAmount: bigint` - Stake amount per window
+- `payload.window: bigint` - Time window in slots until reset
+
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const recurringStakeActions = Actions.set()
+  .stakeRecurringLimit({
+    recurringAmount: 1000000000n, // 1 SOL per window
+    window: 100000n, // slots
+  })
+  .get();
+```
+
+**Permissions Granted:**
+- Stake up to the specified amount per time window
+
+---
+
+### 6. Account Management Actions
+
+#### `subAccount()`
+
+Grants permission to control a subaccount.
+
+**Inputs:** None  
+**Output:** `Actions` instance
+
+**Usage:**
+```typescript
+const subAccountActions = Actions.set().subAccount().get();
+```
+
+**Permissions Granted:**
+- Control and manage subaccount operations
+
+---
+
+## Action Types Reference
+
+### `SolPublicKeyData`
+
+A Solana public key in various formats:
+- String (base58)
+- Uint8Array (32 bytes)
+- PublicKey object
+
+### `NumericType`
+
+Enum defining numeric types:
+```typescript
+enum NumericType {
+  U8, // 8-bit unsigned integer
+  U32, // 32-bit unsigned integer
+  U64, // 64-bit unsigned integer
+  U128, // 128-bit unsigned integer
+}
+```
+
+## Combining Actions
+
+Actions can be chained together to create complex permission sets:
+
+```typescript
+const complexActions = Actions.set()
+  .programAll() // Allow all programs
+  .solLimit({ amount: 1000000000n }) // 1 SOL spending limit
+  .tokenLimit({
+    // Token spending limit
+    mint: 'USDCMintPublicKey',
+    amount: 1000000n,
+  })
+  .tokenDestinationLimit({
+    // Specific destination limit
+    mint: 'USDTMintPublicKey',
+    amount: 500000n,
+    destination: 'RecipientAccount',
+  })
+  .get();
+```
+
+## Return Value: Actions Object
+
+The `.get()` method returns an `Actions` object with the following methods:
+
+### Query Methods
+
+- `count: number` - Number of actions
+- `bytes(): Uint8Array` - Serialized action bytes
+- `isRoot(): boolean` - Check if root action present
+- `canManageAuthority(): boolean` - Check authority management permission
+- `canUseProgram(programId): boolean` - Check program access permission
+- `hasProgramAction(): boolean` - Check if any program action exists
+
+### SOL Spending Methods
+
+- `canSpendSol(amount?): boolean` - Check SOL spending permission
+- `canSpendSolMax(): boolean` - Check unlimited SOL spending
+- `solSpendLimit(): bigint | null` - Get SOL spending limit (null = unlimited)
+- `solSpend(): SpendController` - Get SOL spend controller
+
+### Token Spending Methods
+
+- `canSpendToken(mint, amount?): boolean` - Check token spending permission
+- `canSpendTokenMax(mint): boolean` - Check unlimited token spending
+- `tokenSpendLimit(mint): bigint | null` - Get token spending limit
+- `tokenSpend(mint): SpendController` - Get token spend controller
+
+## Usage Examples
+
+### Simple Token Limit
+
+```typescript
+const actions = Actions.set()
+  .tokenLimit({
+    mint: mintKeypair.publicKey,
+    amount: 1000000n,
+  })
+  .get();
+
+// Check if can spend 500000 tokens
+if (actions.canSpendToken(mintKeypair.publicKey, 500000n)) {
+  console.log('Can spend tokens');
+}
+```
+
+### Program + Destination Limits
+
+```typescript
+const actions = Actions.set()
+  .programAll()
+  .solDestinationLimit({
+    destination: recipientAddress,
+    amount: 500000000n, // 0.5 SOL
+  })
+  .get();
+
+console.log('Actions count:', actions.count); // 2
+console.log('Can use programs:', actions.hasProgramAction()); // true
+console.log('Can spend SOL:', actions.canSpendSol()); // true
+```
+
+### Recurring Subscription Pattern
+
+```typescript
+const subscriptionActions = Actions.set()
+  .tokenRecurringDestinationLimit({
+    mint: usdcMint,
+    recurringAmount: 10000000n, // 10 USDC per month
+    window: 2160000n, // ~30 days in slots
+    destination: serviceProvider,
+  })
+  .programLimit({ programId: tokenProgramId })
+  .get();
+```
+
+This comprehensive documentation covers all available Swig Actions with their inputs, outputs, and practical usage examples.


### PR DESCRIPTION
- Updated `docs.json` to include additional TypeScript pages: `kit` and `actions`.
- Replaced the existing error types documentation in `reference/error-types/index.mdx` with a comprehensive list of error types used in the Swig wallet system, including search functionality and categorized error types.
- Added detailed descriptions, usage examples, and permissions for various Swig Actions in `reference/typescript/actions.mdx`, covering root, program, SOL, token, and staking actions.