### PR TITLE
Limit Developer API docs to API-key endpoints

### DIFF
--- a/developer-api/authentication.mdx
+++ b/developer-api/authentication.mdx
@@ -3,7 +3,8 @@ title: "Authentication and Conventions"
 sidebarTitle: "Authentication"
 ---
 
-Developer API endpoints are REST mappings over Swig backend services.
+Developer API endpoints are API-key guarded REST mappings over Swig backend
+services.
 
 ## Base URL
 
@@ -16,15 +17,18 @@ https://api.onswig.com
 Use the environment-specific base URL provided for your project when working
 against dev, staging, or private deployments.
 
-## Authentication models
+## Authentication
 
-| Auth model | Header | Used by |
-| :--- | :--- | :--- |
-| API key | `Authorization: Bearer sk_...` | Runtime API endpoints under `/transaction`, `/wallet`, `/wallet/api/ramp`, `/paymaster`, and `/identity/api` |
-| Developer portal auth | Portal session or developer-service credential | Tenant-admin endpoints under `/wallet/developer`, `/paymaster/developer`, and `/identity/admin` |
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer sk_your_api_key
+```
 
 Runtime API keys are created in the Developer Portal and should stay on your
 server. Do not expose an API key in browser or mobile client code.
+
+This section intentionally excludes developer-portal admin endpoints.
 
 ## JSON encoding
 

--- a/developer-api/identity.mdx
+++ b/developer-api/identity.mdx
@@ -4,16 +4,22 @@ sidebarTitle: "Identity"
 ---
 
 The Identity API starts login flows, completes OTP/passkey flows, manages role
-and invite operations, and exposes developer-portal client/provider
-configuration.
+and invite operations, and reads identity policies through API-key guarded
+runtime endpoints.
 
 ## Auth
 
-Runtime endpoints under `/identity/api` are API-key or JWT protected depending
-on the flow. Tenant-admin endpoints under `/identity/admin` and
-`/identity/developer` use developer portal auth.
+Use an API key:
 
-## Runtime identity endpoints
+```text
+Authorization: Bearer sk_your_api_key
+```
+
+Some identity flows may return or consume flow-specific tokens after the
+API-key-guarded start point. Developer-portal admin endpoints are intentionally
+omitted from this reference.
+
+## Endpoints
 
 | Method | Path | Operation |
 | :--- | :--- | :--- |
@@ -30,23 +36,6 @@ on the flow. Tenant-admin endpoints under `/identity/admin` and
 | `POST` | `/identity/api/grant-access` | Grant access to an authority |
 | `POST` | `/identity/api/role-remove` | Remove a role |
 | `GET` | `/identity/api/policy/{policy_id}/client/{client_id}` | Read an identity policy for a client |
-
-## Developer identity endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `GET` | `/identity/developer/providers` | List providers available to the organization |
-| `GET` | `/identity/admin/clients` | List identity clients |
-| `GET` | `/identity/admin/clients/disabled` | List disabled identity clients |
-| `POST` | `/identity/admin/clients` | Create an identity client |
-| `GET` | `/identity/admin/clients/{client_id}` | Read one identity client |
-| `PUT` | `/identity/admin/clients/{client_id}` | Update an identity client |
-| `DELETE` | `/identity/admin/clients/{client_id}` | Disable/delete an identity client |
-| `POST` | `/identity/admin/clients/{client_id}/enable` | Re-enable a client |
-| `GET` | `/identity/admin/organizations/{organization_id}/providers` | List organization providers |
-| `POST` | `/identity/admin/organizations/{organization_id}/providers` | Add an organization provider |
-| `DELETE` | `/identity/admin/organizations/{organization_id}/providers/{provider_id}` | Remove an organization provider |
-| `POST` | `/identity/admin/organizations/{organization_id}/providers/{provider_id}/enable` | Enable an organization provider |
 
 ## Start OAuth auth
 
@@ -114,21 +103,5 @@ The response includes `challengeId`, `maskedEmail`, `expiresAt`,
 The response returns a `challengeId` and `webauthnOptionsJson` for
 `navigator.credentials`.
 
-## Create a client
-
-`POST /identity/admin/clients`
-
-```json
-{
-  "organizationId": "org_123",
-  "displayName": "Production web app",
-  "callbackUrls": ["https://app.example/callback"],
-  "paymasterEnabled": true,
-  "allowSignup": true,
-  "codeChallengeMethod": "S256",
-  "defaultRoleTemplateId": "policy_123"
-}
-```
-
-Client responses include the generated `clientId` and `clientSecret`. Treat the
-client secret as sensitive.
+Identity client and organization-provider configuration is handled through
+developer-portal admin surfaces, not API-key runtime endpoints.

--- a/developer-api/index.mdx
+++ b/developer-api/index.mdx
@@ -3,8 +3,8 @@ title: "Developer API"
 sidebarTitle: "Overview"
 ---
 
-The Developer API is the REST surface behind Swig's hosted wallet, paymaster,
-identity, ramp, and developer-portal operations.
+The Developer API is the API-key guarded REST surface behind Swig's hosted
+wallet, transaction, paymaster, identity, and ramp runtime APIs.
 
 Use it when you want to call Swig's backend directly instead of using the
 Developer SDK helpers.
@@ -24,19 +24,19 @@ curl "https://api.onswig.com/paymaster/balance?network=devnet" \
 
 <CardGroup cols={2}>
   <Card title="Authentication" icon="key" href="/developer-api/authentication">
-    API keys, portal auth, JSON encoding, and request conventions
+    API keys, JSON encoding, and request conventions
   </Card>
   <Card title="Transactions" icon="send" href="/developer-api/transactions">
     Prepare wallet creation, transfers, swaps, and recovery transactions
   </Card>
   <Card title="Wallets" icon="wallet" href="/developer-api/wallets">
-    Lookup Swigs, inspect balances and roles, manage policies, and close ATAs
+    Lookup Swigs and inspect balances, roles, policies, and token history
   </Card>
   <Card title="Paymaster" icon="credit-card" href="/developer-api/paymaster">
-    Sign, sponsor, check balances, and manage paymaster limits
+    Sign, sponsor, and check paymaster balances
   </Card>
   <Card title="Identity" icon="fingerprint" href="/developer-api/identity">
-    Identity provider login, OTP, passkeys, invites, clients, and org providers
+    Identity provider login, OTP, passkeys, invites, and role operations
   </Card>
   <Card title="Ramp" icon="credit-card" href="/developer-api/ramp">
     Quote ramp flows, create sessions, and read ramp transaction state
@@ -48,9 +48,9 @@ curl "https://api.onswig.com/paymaster/balance?network=devnet" \
 | Group | Use it for |
 | :--- | :--- |
 | [Transaction API](/developer-api/transactions) | Preparing unsigned or partially signed Solana transactions for Swig wallet flows |
-| [Wallet API](/developer-api/wallets) | Reading Swig wallet state, policies, balances, roles, and developer wallet admin resources |
-| [Paymaster API](/developer-api/paymaster) | Signing or sponsoring transactions and managing paymaster balances and limits |
-| [Identity API](/developer-api/identity) | Starting login flows, managing identity clients, and configuring organization providers |
+| [Wallet API](/developer-api/wallets) | Reading Swig wallet state, policies, balances, roles, and token history |
+| [Paymaster API](/developer-api/paymaster) | Signing or sponsoring transactions and checking paymaster balances |
+| [Identity API](/developer-api/identity) | Starting login flows, OTP/passkey flows, invites, and role operations |
 | [Ramp API](/developer-api/ramp) | Creating fiat ramp quotes, sessions, and transaction-history views |
 
 ## SDK or API

--- a/developer-api/paymaster.mdx
+++ b/developer-api/paymaster.mdx
@@ -3,15 +3,20 @@ title: "Paymaster API"
 sidebarTitle: "Paymaster"
 ---
 
-The Paymaster API signs or sponsors transactions and exposes paymaster balance
-and limit management.
+The Paymaster API signs or sponsors transactions and reads paymaster balance
+state through API-key guarded runtime endpoints.
 
 ## Auth
 
-Runtime endpoints use API-key auth. Developer endpoints under
-`/paymaster/developer` use developer portal auth.
+Use an API key:
 
-## Runtime endpoints
+```text
+Authorization: Bearer sk_your_api_key
+```
+
+Developer-portal admin endpoints are intentionally omitted from this reference.
+
+## Endpoints
 
 | Method | Path | Operation |
 | :--- | :--- | :--- |
@@ -22,15 +27,6 @@ Runtime endpoints use API-key auth. Developer endpoints under
 | `POST` | `/sign` | Legacy alias for `/paymaster/sign` |
 | `POST` | `/paymaster/sponsor` | Sign and submit a transaction |
 | `POST` | `/sponsor` | Legacy alias for `/paymaster/sponsor` |
-
-## Developer endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `GET` | `/paymaster/developer/organizations/{organization_id}/paymasters/{paymaster_id}/daily-limit` | Read paymaster daily limits |
-| `POST` | `/paymaster/developer/organizations/{organization_id}/paymasters/{paymaster_id}/daily-limit` | Update paymaster daily limits |
-| `GET` | `/paymaster/developer/organizations/{organization_id}/idp-paymaster` | Read the organization IdP paymaster |
-| `POST` | `/paymaster/developer/organizations/{organization_id}/idp-paymaster/get-or-create` | Get or create the organization IdP paymaster |
 
 ## Get balance
 
@@ -98,20 +94,5 @@ Response:
 }
 ```
 
-## Update daily limits
-
-`POST /paymaster/developer/organizations/{organization_id}/paymasters/{paymaster_id}/daily-limit`
-
-```json
-{
-  "dailyApiThreshold": 1000,
-  "hasDailyApiThreshold": true,
-  "dailySolThresholdLamports": "1000000000",
-  "hasDailySolThreshold": true,
-  "dailyUserSolThresholdLamports": "10000000",
-  "hasDailyUserSolThreshold": true
-}
-```
-
-Daily limit responses return the updated paymaster limit state, including
-organization id, paymaster id, thresholds, and update time.
+Paymaster limit configuration is handled through developer-portal admin
+surfaces, not API-key runtime endpoints.

--- a/developer-api/wallets.mdx
+++ b/developer-api/wallets.mdx
@@ -3,15 +3,20 @@ title: "Wallet API"
 sidebarTitle: "Wallets"
 ---
 
-The Wallet API reads Swig wallet state and exposes developer-portal wallet
-administration resources such as policies and closeable token accounts.
+The Wallet API reads Swig wallet state through API-key guarded runtime
+endpoints.
 
 ## Auth
 
-Runtime wallet endpoints use API-key auth. Developer admin endpoints under
-`/wallet/developer` use developer portal auth.
+Use an API key:
 
-## Runtime wallet endpoints
+```text
+Authorization: Bearer sk_your_api_key
+```
+
+Developer-portal admin endpoints are intentionally omitted from this reference.
+
+## Endpoints
 
 | Method | Path | Operation |
 | :--- | :--- | :--- |
@@ -24,30 +29,6 @@ Runtime wallet endpoints use API-key auth. Developer admin endpoints under
 | `GET` | `/wallet/swig/{swig_config_address}/token-balances` | List token balances |
 | `GET` | `/wallet/swig/{swig_config_address}/token-transactions` | List token transaction history |
 | `GET` | `/wallet/swig/{swig_config_address}/roles` | List roles and actions |
-
-## Developer wallet endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `GET` | `/wallet/developer/organizations/{organization_id}/wallets` | List organization wallets and token balances |
-| `GET` | `/wallet/developer/organizations/{organization_id}/policy-templates` | List reusable policy templates |
-| `GET` | `/wallet/developer/organizations/{organization_id}/policies` | List organization policies |
-| `GET` | `/wallet/developer/organizations/{organization_id}/policies/{policy_id}` | Read one policy |
-| `POST` | `/wallet/developer/organizations/{organization_id}/policies` | Create a policy |
-| `PATCH` | `/wallet/developer/organizations/{organization_id}/policies/{policy_id}` | Update a policy |
-| `DELETE` | `/wallet/developer/organizations/{organization_id}/policies/{policy_id}` | Delete a policy |
-
-## Closeable ATA endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `GET` | `/wallet/developer/organizations/{organization_id}/closeable-signers` | List signers with closeable token accounts |
-| `GET` | `/wallet/developer/organizations/{organization_id}/closeable-atas` | List closeable ATAs for a signer |
-| `GET` | `/wallet/developer/organizations/{organization_id}/closeable-atas:summary` | Summarize closeable and pending ATA value |
-| `GET` | `/wallet/developer/organizations/{organization_id}/close-batches` | List submitted close batches |
-| `POST` | `/wallet/developer/organizations/{organization_id}/close-batches:lookup` | Look up ATAs for close batch signatures |
-| `POST` | `/wallet/developer/organizations/{organization_id}/close-ata-batches` | Submit close-ATA batches |
-| `POST` | `/wallet/developer/organizations/{organization_id}/resolve-pending-close-ata-batches` | Resolve pending close batches |
 
 ## List token balances
 
@@ -79,40 +60,8 @@ Query parameters:
 | `network` | enum | `NETWORK_DEVNET` or `NETWORK_MAINNET` |
 | `limit` | number | Maximum number of transactions to return |
 
-## Create a policy
+## Get policy
 
-`POST /wallet/developer/organizations/{organization_id}/policies`
-
-```json
-{
-  "name": "daily-transfer-policy",
-  "description": "Initial user can transfer a limited amount each day.",
-  "signer": {
-    "mode": "CREATE_POLICY_SIGNER_MODE_CREATE",
-    "name": "Initial user",
-    "authorityType": "POLICY_AUTHORITY_TYPE_ED25519",
-    "publicKey": "UserPublicKey"
-  },
-  "permission": {
-    "mode": "CREATE_POLICY_PERMISSION_MODE_CREATE",
-    "name": "Daily SOL transfer",
-    "actions": [
-      {
-        "type": "SolRecurringLimit",
-        "amount": "1000000000",
-        "windowSeconds": 86400
-      }
-    ]
-  }
-}
-```
-
-Policy create and update requests can include:
-
-| Field | Description |
-| :--- | :--- |
-| `signer` | Use an existing signer, create one, or skip signer creation |
-| `permission` | Use an existing permission or create a permission from actions |
-| `initialUser` | Initial wallet authority and key source |
-| `guardian` | Optional guardian authority and recovery delay |
-| `additionalUsers` | Extra authorities added when wallets are created from the policy |
+`GET /wallet/policies/{policy_id}` reads a policy visible to the API-key
+organization. Policy creation and policy administration are portal-admin flows,
+not API-key runtime endpoints.

--- a/docs.json
+++ b/docs.json
@@ -243,7 +243,7 @@
       {
         "product": "Developer API",
         "icon": "code",
-        "description": "REST reference for Swig's hosted developer and runtime APIs",
+        "description": "REST reference for Swig's API-key guarded runtime APIs",
         "groups": [
           {
             "group": "Start Here",

--- a/examples/dev-portal/api-reference.mdx
+++ b/examples/dev-portal/api-reference.mdx
@@ -3,7 +3,8 @@ title: "REST API Reference"
 sidebarTitle: "REST API"
 ---
 
-The REST API reference now lives in the Developer API product section.
+The API-key guarded REST reference now lives in the Developer API product
+section.
 
 <Card title="Open Developer API Reference" icon="code" href="/developer-api">
   View current endpoint paths, payloads, response fields, authentication, and

--- a/overview/developer-api.mdx
+++ b/overview/developer-api.mdx
@@ -4,14 +4,14 @@ sidebarTitle: "Developer API"
 ---
 
 Use Developer API when you want direct REST access to Swig's hosted backend
-surfaces instead of going through SDK helpers.
+runtime surfaces instead of going through SDK helpers.
 
 Start there for:
 
 - preparing wallet transactions through REST
 - sponsoring or signing transactions with a paymaster
 - reading wallet balances, roles, and token history
-- managing developer-portal policies, clients, providers, and paymaster limits
+- starting identity login, OTP, passkey, invite, and role flows
 - creating ramp quotes and sessions
 
 <Card title="Open Developer API Docs" icon="code" href="/developer-api">


### PR DESCRIPTION
## Summary
- remove developer-portal admin endpoint listings from the Developer API reference
- retitle the section as API-key guarded runtime REST docs
- keep only API-key runtime groups: transaction, wallet, paymaster, identity, and ramp

## Validation
- parsed `docs.json` and verified all navigation targets exist
- checked internal links on changed Developer API pages
- verified non-API-key path prefixes are not listed in `developer-api/`