### PR TITLE
Remove Developer API endpoint tables

### DIFF
--- a/developer-api/identity.mdx
+++ b/developer-api/identity.mdx
@@ -19,24 +19,6 @@ Some identity flows may return or consume flow-specific tokens after the
 API-key-guarded start point. Developer-portal admin endpoints are intentionally
 omitted from this reference.
 
-## Endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `GET` | `/identity/api/providers` | List configured login providers for a client |
-| `GET` | `/identity/api/auth/start` | Start an OAuth-style auth flow |
-| `POST` | `/identity/api/auth/email/start` | Start first-party email OTP |
-| `POST` | `/identity/api/auth/sms/start` | Start first-party SMS OTP |
-| `POST` | `/identity/api/auth/passkey/start` | Start a WebAuthn passkey ceremony |
-| `POST` | `/identity/api/auth/passkey/finish` | Finish a WebAuthn passkey ceremony |
-| `POST` | `/identity/api/signup` | Create or find the user's Swig after identity proof |
-| `POST` | `/identity/api/role-add` | Add a role using an identity proof |
-| `POST` | `/identity/api/invite/initiate` | Create an invite for another authority |
-| `POST` | `/identity/api/invite/accept` | Accept an invite |
-| `POST` | `/identity/api/grant-access` | Grant access to an authority |
-| `POST` | `/identity/api/role-remove` | Remove a role |
-| `GET` | `/identity/api/policy/{policy_id}/client/{client_id}` | Read an identity policy for a client |
-
 ## Start OAuth auth
 
 `GET /identity/api/auth/start`

--- a/developer-api/paymaster.mdx
+++ b/developer-api/paymaster.mdx
@@ -16,18 +16,6 @@ Authorization: Bearer sk_your_api_key
 
 Developer-portal admin endpoints are intentionally omitted from this reference.
 
-## Endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `GET` | `/paymaster/test` | Validate the API key and return caller identity metadata |
-| `GET` | `/test` | Legacy alias for `/paymaster/test` |
-| `GET` | `/paymaster/balance` | Read paymaster balance for an API or IdP paymaster |
-| `POST` | `/paymaster/sign` | Add the paymaster signature to a transaction |
-| `POST` | `/sign` | Legacy alias for `/paymaster/sign` |
-| `POST` | `/paymaster/sponsor` | Sign and submit a transaction |
-| `POST` | `/sponsor` | Legacy alias for `/paymaster/sponsor` |
-
 ## Get balance
 
 `GET /paymaster/balance`

--- a/developer-api/ramp.mdx
+++ b/developer-api/ramp.mdx
@@ -14,16 +14,6 @@ Use an API key:
 Authorization: Bearer sk_your_api_key
 ```
 
-## Endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `GET` | `/wallet/api/ramp/options` | List supported countries, fiat currencies, crypto currencies, and payment methods |
-| `POST` | `/wallet/api/ramp/quote` | Quote a ramp transaction |
-| `POST` | `/wallet/api/ramp/sessions` | Create a hosted ramp session |
-| `GET` | `/wallet/api/ramp/transactions/{transaction_id}` | Read one ramp transaction |
-| `GET` | `/wallet/api/ramp/wallets/{wallet_id}/transactions` | List ramp transactions for a wallet |
-
 ## Get options
 
 `GET /wallet/api/ramp/options`

--- a/developer-api/transactions.mdx
+++ b/developer-api/transactions.mdx
@@ -15,21 +15,6 @@ Use an API key:
 Authorization: Bearer sk_your_api_key
 ```
 
-## Endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `POST` | `/transaction/prepare` | Prepare a grouped set of wallet operations |
-| `POST` | `/transaction/wallet/create` | Prepare or create a Swig wallet |
-| `POST` | `/transaction/wallet/recovery-authority/add` | Prepare adding a recovery authority |
-| `POST` | `/transaction/recovery/configure` | Prepare recovery configuration |
-| `POST` | `/transaction/transfer/sol` | Prepare a SOL transfer |
-| `POST` | `/transaction/transfer/spl-token` | Prepare an SPL token transfer |
-| `POST` | `/transaction/swap/jupiter` | Prepare a Jupiter swap |
-| `POST` | `/transaction/recovery/start` | Prepare starting recovery |
-| `POST` | `/transaction/recovery/cancel` | Prepare canceling recovery |
-| `POST` | `/transaction/recovery/execute` | Prepare executing recovery |
-
 ## Common request fields
 
 | Field | Type | Description |

--- a/developer-api/wallets.mdx
+++ b/developer-api/wallets.mdx
@@ -16,20 +16,6 @@ Authorization: Bearer sk_your_api_key
 
 Developer-portal admin endpoints are intentionally omitted from this reference.
 
-## Endpoints
-
-| Method | Path | Operation |
-| :--- | :--- | :--- |
-| `POST` | `/wallet/swig/lookup` | Look up a Swig by `clientId`, `swigId`, and `network` |
-| `GET` | `/wallet/swig/status` | Check whether a Swig exists and whether signup/paymaster are enabled |
-| `GET` | `/wallet/policies/{policy_id}` | Read a wallet policy by id |
-| `POST` | `/wallet/swig/auth/check` | Check whether a Swig is authorized for a client |
-| `POST` | `/wallet/swig/session` | Create a Swig session for a role template |
-| `GET` | `/wallet/swig/{swig_config_address}/balance/usd` | Read total USD balance |
-| `GET` | `/wallet/swig/{swig_config_address}/token-balances` | List token balances |
-| `GET` | `/wallet/swig/{swig_config_address}/token-transactions` | List token transaction history |
-| `GET` | `/wallet/swig/{swig_config_address}/roles` | List roles and actions |
-
 ## List token balances
 
 `GET /wallet/swig/{swig_config_address}/token-balances`


### PR DESCRIPTION
## Summary
- remove the front-loaded endpoint inventory tables from Developer API pages
- keep the endpoint-specific sections and examples in place

## Validation
- parsed `docs.json` and verified navigation targets
- verified no `## Endpoints` sections or method/path inventory tables remain in `developer-api/`
- checked Developer API internal links
- `git diff --check`