### PR TITLE
docs(developer-sdk): add Python language chooser

### DIFF
--- a/developer-sdk/add-guardian-after-creation.mdx
+++ b/developer-sdk/add-guardian-after-creation.mdx
@@ -23,7 +23,9 @@ The hosted endpoints behind this flow are:
 
 ## Prepare the setup
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const wallet = swig.wallets.use(existingWallet);
 
 const setup = await wallet.recovery.prepareSetup({
@@ -34,20 +36,33 @@ const setup = await wallet.recovery.prepareSetup({
 });
 ```
 
+```python Python
+wallet = swig.wallets.use(existing_wallet)
+
+setup = await wallet.recovery.prepare_setup(
+    fee_payer=fee_payer,
+    requester_authority=requester_authority,
+    guardian_pubkey=guardian_public_key,
+    delay_seconds=86_400,
+)
+```
+
+</CodeGroup>
+
 This returns:
 
-- `setup.addAuthorityTransaction`
-- `setup.configureRecoveryTransaction`
+- `setup.addAuthorityTransaction` / `setup.add_authority_transaction`
+- `setup.configureRecoveryTransaction` / `setup.configure_recovery_transaction`
 
 ## Signing model
 
 | Transaction | Who signs |
 | :--- | :--- |
-| `setup.addAuthorityTransaction` | the wallet's current authority |
-| `setup.configureRecoveryTransaction` | the backend recovery operator already signs it |
+| `setup.addAuthorityTransaction` / `setup.add_authority_transaction` | the wallet's current authority |
+| `setup.configureRecoveryTransaction` / `setup.configure_recovery_transaction` | the backend recovery operator already signs it |
 
-After the current authority signs `addAuthorityTransaction`, the remaining work
-is fee-payer or sponsor submission for the configure transaction.
+After the current authority signs the add-authority transaction, the remaining
+work is fee-payer or sponsor submission for the configure transaction.
 
 ## When to use this page instead of initial recovery setup
 

--- a/developer-sdk/client-signing.mdx
+++ b/developer-sdk/client-signing.mdx
@@ -8,14 +8,17 @@ transactions.
 
 ## What to look for
 
-If a prepared transaction has `signatureRequests.length > 0`, the client still
-needs to sign it before submission.
+If a prepared transaction has a non-empty `signatureRequests` /
+`signature_requests` collection, the client still needs to sign it before
+submission.
 
 ## Ed25519 signing
 
 For normal Solana-key signing, use `signPreparedTransaction(...)`:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 import {
   signPreparedTransaction,
   type PreparedTransaction,
@@ -35,11 +38,24 @@ const signed = await signPreparedTransaction(prepared, {
 });
 ```
 
+```python Python
+from swig_developer_sdk import sign_prepared_transaction
+
+signed = await sign_prepared_transaction(
+    prepared,
+    sign_transaction=application_ed25519_signer,
+)
+```
+
+</CodeGroup>
+
 ## Secp256r1 and passkeys
 
 For passkey-backed prepared transactions, use the Swig signing helpers:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 import {
   createSecp256r1PasskeySigningFn,
   signPreparedSwigTransaction,
@@ -55,13 +71,31 @@ const signed = await signPreparedSwigTransaction(prepared, {
 });
 ```
 
+```python Python
+from swig_developer_sdk import (
+    create_secp256r1_passkey_signing_fn,
+    sign_prepared_swig_transaction,
+)
+
+passkey_signing_fn = create_secp256r1_passkey_signing_fn(get_assertion)
+
+signed = await sign_prepared_swig_transaction(
+    prepared,
+    secp256r1=passkey_signing_fn,
+)
+```
+
+</CodeGroup>
+
 ## Secp256k1 and EVM wallets
 
 For EVM-backed prepared transactions, use the EVM helper. It wraps an EIP-1193
 provider with `personal_sign` and adds the Ethereum message prefix expected by
 Swig's `secp256k1` authority payload.
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 import {
   createSecp256k1EvmSigningFn,
   signPreparedSwigTransaction,
@@ -80,6 +114,25 @@ const signed = await signPreparedSwigTransaction(prepared, {
   secp256k1: evmSigningFn,
 });
 ```
+
+```python Python
+from swig_developer_sdk import (
+    create_secp256k1_evm_signing_fn,
+    sign_prepared_swig_transaction,
+)
+
+evm_signing_fn = create_secp256k1_evm_signing_fn(
+    provider=evm_provider,
+    address=evm_address,
+)
+
+signed = await sign_prepared_swig_transaction(
+    prepared,
+    secp256k1=evm_signing_fn,
+)
+```
+
+</CodeGroup>
 
 ## After signing
 

--- a/developer-sdk/create-wallets.mdx
+++ b/developer-sdk/create-wallets.mdx
@@ -10,16 +10,18 @@ shows up clearly.
 
 You can create a wallet either:
 
-- from a policy with `policyId`
-- from an inline `initialUser`
+- from a policy with `policyId` / `policy_id`
+- from an inline `initialUser` / `initial_user`
 
-If `policyId` is omitted, the backend can create a no-recovery wallet from the
-inline authority you provide. Common authority shapes are `ed25519`,
+If the policy ID is omitted, the backend can create a no-recovery wallet from
+the inline authority you provide. Common authority shapes are `ed25519`,
 `secp256k1`, and `secp256r1`.
 
 ## Basic create flow
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const created = await swig.wallets.create({
   feePayer,
   initialUser: {
@@ -30,9 +32,24 @@ const created = await swig.wallets.create({
 });
 ```
 
+```python Python
+created = await swig.wallets.create(
+    fee_payer=fee_payer,
+    initial_user={
+        "ed25519": {
+            "publicKey": user_public_key,
+        },
+    },
+)
+```
+
+</CodeGroup>
+
 Passkey-backed creation works the same way with `secp256r1`:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const created = await swig.wallets.create({
   feePayer,
   initialUser: {
@@ -43,9 +60,24 @@ const created = await swig.wallets.create({
 });
 ```
 
+```python Python
+created = await swig.wallets.create(
+    fee_payer=fee_payer,
+    initial_user={
+        "secp256r1": {
+            "publicKey": passkey_public_key,
+        },
+    },
+)
+```
+
+</CodeGroup>
+
 EVM-backed creation works the same way with `secp256k1`:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const created = await swig.wallets.create({
   feePayer,
   initialUser: {
@@ -56,17 +88,30 @@ const created = await swig.wallets.create({
 });
 ```
 
+```python Python
+created = await swig.wallets.create(
+    fee_payer=fee_payer,
+    initial_user={
+        "secp256k1": {
+            "publicKey": evm_public_key,
+        },
+    },
+)
+```
+
+</CodeGroup>
+
 ## What you get back
 
 The result is not just one transaction. It is a categorized create plan:
 
-| Field | Meaning |
+| TypeScript / Python | Meaning |
 |-------|---------|
 | `wallet` | the config address and wallet address |
 | `transactions` | full ordered transaction list |
-| `clientAuthorityTransactions` | transactions the initial authority must sign |
-| `operatorSignedTransactions` | transactions already signed by the backend operator |
-| `feePayerOnlyTransactions` | transactions that only need fee payer or sponsor handling |
+| `clientAuthorityTransactions` / `client_authority_transactions` | transactions the initial authority must sign |
+| `operatorSignedTransactions` / `operator_signed_transactions` | transactions already signed by the backend operator |
+| `feePayerOnlyTransactions` / `fee_payer_only_transactions` | transactions that only need fee payer or sponsor handling |
 
 For plain non-recovery creates, this usually collapses to one main creation
 transaction plus any client authority signing the create flow needs.
@@ -74,22 +119,23 @@ transaction plus any client authority signing the create flow needs.
 ## Recovery-enabled create flows
 
 If the policy is recovery-enabled and the SDK can derive both the requester
-authority and guardian information, `create(...)` also returns
-`recoverySetup`.
+authority and guardian information, `create(...)` also returns `recoverySetup`
+/ `recovery_setup`.
 
 That setup plan is not the same thing as completed recovery setup. It is the
-follow-up input for `wallet.recovery.prepareSetup(...)`.
+follow-up input for `wallet.recovery.prepareSetup(...)` /
+`wallet.recovery.prepare_setup(...)`.
 
 ## What to submit
 
 Always submit the prepared `transactions` in order. Do not reorder the list.
 
-If `clientAuthorityTransactions.length > 0`, those transactions must be signed
-by the client authority before submission.
+If the client-authority transaction collection is not empty, those transactions
+must be signed by the client authority before submission.
 
-If `operatorSignedTransactions.length > 0`, treat them as already operator
-signed. They still need fee payer or sponsor submission, but not another
-authority signature.
+If the operator-signed transaction collection is not empty, treat those
+transactions as already operator signed. They still need fee payer or sponsor
+submission, but not another authority signature.
 
 ## What to read next
 

--- a/developer-sdk/custom-execution.mdx
+++ b/developer-sdk/custom-execution.mdx
@@ -19,7 +19,9 @@ Use it when:
 
 ## Example
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const prepared = await wallet.execute({
   instructions: [
     {
@@ -40,6 +42,29 @@ const prepared = await wallet.execute({
 });
 ```
 
+```python Python
+from swig_developer_sdk import SolanaAccountMeta, SolanaInstructionInput
+
+prepared = await wallet.execute(
+    instructions=(
+        SolanaInstructionInput(
+            program_id=target_program_id,
+            accounts=(
+                SolanaAccountMeta(
+                    pubkey=writable_account,
+                    is_writable=True,
+                ),
+                SolanaAccountMeta(pubkey=readonly_account),
+            ),
+            data=instruction_data,
+        ),
+    ),
+    address_lookup_table_accounts=(lookup_table_address,),
+)
+```
+
+</CodeGroup>
+
 The SDK normalizes the instruction input and sends it to the hosted execute
 endpoint for preparation.
 
@@ -47,7 +72,7 @@ endpoint for preparation.
 
 This is still a prepared transaction result. That means:
 
-- your app still checks `signatureRequests`
+- your app still checks `signatureRequests` / `signature_requests`
 - the client still signs if required
 - your app still chooses direct submission or sponsor submission
 

--- a/developer-sdk/framework-proxies.mdx
+++ b/developer-sdk/framework-proxies.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Use Next.js or NestJS"
-sidebarTitle: "Use Next.js or NestJS"
+title: "Use Proxy Helpers"
+sidebarTitle: "Use Proxy Helpers"
 ---
 
 If your app only needs a safe server-side proxy around transaction preparation,
@@ -43,6 +43,27 @@ export class SwigController {
 }
 ```
 
+## Python
+
+Create one handler, then adapt your framework's request and response objects at
+the route boundary:
+
+```python
+from swig_developer_sdk import SwigProxyConfig, create_swig_proxy_handler
+
+swig_handler = create_swig_proxy_handler(
+    SwigProxyConfig(api_key=swig_api_key, network="devnet")
+)
+
+response = await swig_handler.handle(
+    method="POST",
+    path="/transfer/sol",
+    body=request_body,
+)
+```
+
+Return `response.body` with `response.status` from your framework route.
+
 ## Routes the helpers cover
 
 The framework helpers cover:
@@ -57,6 +78,11 @@ The framework helpers cover:
 
 Once your proxy exists, browser code can use `SwigBrowserClient` and call only
 your local app routes:
+
+<Note>
+  `SwigBrowserClient` is TypeScript-only. Python applications expose the proxy
+  server-side and use their normal frontend stack for browser signing.
+</Note>
 
 ```typescript
 import { SwigBrowserClient } from '@swig-wallet/developer-sdk/browser';

--- a/developer-sdk/index.mdx
+++ b/developer-sdk/index.mdx
@@ -3,11 +3,36 @@ title: "What the Developer SDK Does"
 sidebarTitle: "What It Does"
 ---
 
-The Swig Developer SDK is the current hosted wallet SDK in
-`swig-ts/packages/developer-sdk`.
+The Swig Developer SDK is the current hosted wallet SDK for TypeScript and
+Python.
 
 Your server keeps the API key. Your app prepares wallet operations on the
 server. Your client signs only the prepared transactions it is responsible for.
+
+## Choose your language
+
+Install the SDK for your server runtime. The examples throughout these docs use
+the same TypeScript and Python selector.
+
+<Tabs>
+
+<Tab title="TypeScript">
+
+```bash
+bun add @swig-wallet/developer-sdk
+```
+
+</Tab>
+
+<Tab title="Python">
+
+```bash
+pip install swig-developer-sdk
+```
+
+</Tab>
+
+</Tabs>
 
 ## What you can build
 
@@ -18,7 +43,8 @@ With this SDK, you can:
 - run custom instruction execution against an existing wallet
 - add guardian-based recovery flows
 - submit signed transactions through Swig's sponsor path
-- expose all of that through Next.js, NestJS, or your own backend routes
+- expose all of that through Next.js, NestJS, a Python proxy handler, or your
+  own backend routes
 
 ## Use this SDK when
 
@@ -30,7 +56,7 @@ With this SDK, you can:
 ## Three ways to integrate
 
 - use the server SDK directly
-- use the built-in Next.js or NestJS proxy helpers
+- use a built-in TypeScript framework helper or the Python proxy handler
 - use the browser client against your own proxy routes
 
 ## What it is not

--- a/developer-sdk/integration-paths.mdx
+++ b/developer-sdk/integration-paths.mdx
@@ -12,26 +12,49 @@ auth checks, request validation, and response format.
 
 Main entrypoint:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 import { SwigClient } from '@swig-wallet/developer-sdk/server/typescript';
 ```
 
-## 2. Next.js or NestJS proxy helpers
+```python Python
+from swig_developer_sdk import SwigClient
+```
+
+</CodeGroup>
+
+## 2. Proxy helpers
 
 Use the framework helpers when you want the API key to stay on the server, but
 you do not want to implement each prepare route yourself.
 
 Main entrypoints:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 import { createSwigRouteHandlers } from '@swig-wallet/developer-sdk/next';
 import { createSwigNestHandler } from '@swig-wallet/developer-sdk/nest';
 ```
+
+```python Python
+from swig_developer_sdk import SwigProxyConfig, create_swig_proxy_handler
+
+handler = create_swig_proxy_handler(SwigProxyConfig())
+```
+
+</CodeGroup>
 
 ## 3. Browser client against your own proxy
 
 Use the browser client when your frontend should work with wallet handles and
 prepared results, while still calling only your own app routes.
+
+<Note>
+  The browser client is TypeScript-only. Python provides the equivalent
+  server-side proxy handler, while browser signing remains in your frontend.
+</Note>
 
 Main entrypoint:
 

--- a/developer-sdk/recovery-flows.mdx
+++ b/developer-sdk/recovery-flows.mdx
@@ -20,12 +20,12 @@ The SDK breaks recovery into three stages:
 - later start, cancel, or execute a recovery
 
 If the policy is not recovery-enabled, treat the result as a normal wallet
-create flow and expect `recoverySetup` to be absent.
+create flow and expect `recoverySetup` / `recovery_setup` to be absent.
 
 ## Main SDK entrypoints
 
 - `swig.wallets.create(...)`
-- `wallet.recovery.prepareSetup(...)`
+- `wallet.recovery.prepareSetup(...)` / `wallet.recovery.prepare_setup(...)`
 - `wallet.recovery.start(...)`
 - `wallet.recovery.cancel(...)`
 - `wallet.recovery.execute(...)`

--- a/developer-sdk/recovery-runtime.mdx
+++ b/developer-sdk/recovery-runtime.mdx
@@ -9,7 +9,9 @@ Once recovery is configured, the runtime flow is straightforward.
 
 The guardian starts a recovery with:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const start = await wallet.recovery.start({
   feePayer,
   guardianPubkey: guardianPublicKey,
@@ -17,26 +19,55 @@ const start = await wallet.recovery.start({
 });
 ```
 
+```python Python
+start = await wallet.recovery.start(
+    fee_payer=fee_payer,
+    guardian_pubkey=guardian_public_key,
+    new_authority=new_authority_public_key,
+)
+```
+
+</CodeGroup>
+
 ## Cancel recovery
 
 The current wallet authority cancels a pending recovery with:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const cancel = await wallet.recovery.cancel({
   feePayer,
 });
 ```
 
+```python Python
+cancel = await wallet.recovery.cancel(fee_payer=fee_payer)
+```
+
+</CodeGroup>
+
 ## Execute recovery
 
 After the configured delay, the guardian executes recovery with:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const execute = await wallet.recovery.execute({
   feePayer,
   newAuthority: newAuthorityPublicKey,
 });
 ```
+
+```python Python
+execute = await wallet.recovery.execute(
+    fee_payer=fee_payer,
+    new_authority=new_authority_public_key,
+)
+```
+
+</CodeGroup>
 
 ## Signing model
 
@@ -49,9 +80,9 @@ const execute = await wallet.recovery.execute({
 The SDK can also read policy metadata through `swig.wallets.getPolicy(policyId)`.
 That is where it finds fields like:
 
-- `guardianEnabled`
-- `guardianAuthority`
-- `guardianDelaySeconds`
+- `guardianEnabled` / `guardian_enabled`
+- `guardianAuthority` / `guardian_authority`
+- `guardianDelaySeconds` / `guardian_delay_seconds`
 
 Most apps should still rely on `created.recoverySetup` as the setup source of
 truth and treat policy reads as supporting metadata.

--- a/developer-sdk/recovery-setup.mdx
+++ b/developer-sdk/recovery-setup.mdx
@@ -11,7 +11,9 @@ instead if the wallet already exists and you are enabling recovery later.
 
 ## Create from a recovery-enabled policy
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const created = await swig.wallets.create({
   feePayer,
   policyId,
@@ -27,23 +29,46 @@ const created = await swig.wallets.create({
 });
 ```
 
+```python Python
+from swig_developer_sdk import RecoveryOptions
+
+created = await swig.wallets.create(
+    fee_payer=fee_payer,
+    policy_id=policy_id,
+    initial_user={
+        "secp256r1": {
+            "publicKey": passkey_public_key,
+        },
+    },
+    recovery=RecoveryOptions(
+        guardian_pubkey=guardian_public_key,
+        delay_seconds=86_400,
+    ),
+)
+```
+
+</CodeGroup>
+
 If the policy is recovery-enabled and the SDK can derive the requester
-authority and guardian information, `create(...)` returns `recoverySetup`.
+authority and guardian information, `create(...)` returns `recoverySetup` /
+`recovery_setup`.
 
 ## What `create(...)` gives you
 
 For a recovery-enabled flow, the important pieces are:
 
-- `creationTransaction`
-- `clientAuthorityTransactions`
-- `operatorSignedTransactions`
-- `recoverySetup`
+- `creationTransaction` / `creation_transaction`
+- `clientAuthorityTransactions` / `client_authority_transactions`
+- `operatorSignedTransactions` / `operator_signed_transactions`
+- `recoverySetup` / `recovery_setup`
 
 ## Prepare the follow-up setup
 
 After wallet creation is submitted, prepare recovery setup:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const wallet = swig.wallets.use(created.wallet);
 
 const setup = await wallet.recovery.prepareSetup({
@@ -52,22 +77,38 @@ const setup = await wallet.recovery.prepareSetup({
 });
 ```
 
+```python Python
+wallet = swig.wallets.use(created.wallet)
+assert created.recovery_setup is not None
+
+setup = await wallet.recovery.prepare_setup(
+    fee_payer=fee_payer,
+    guardian_pubkey=created.recovery_setup.guardian_pubkey,
+    requester_authority=created.recovery_setup.requester_authority,
+    delay_seconds=created.recovery_setup.delay_seconds,
+    target_role_id=created.recovery_setup.target_role_id,
+)
+```
+
+</CodeGroup>
+
 That returns:
 
-- `addAuthorityTransaction`
-- `configureRecoveryTransaction`
+- `addAuthorityTransaction` / `add_authority_transaction`
+- `configureRecoveryTransaction` / `configure_recovery_transaction`
 
 ## Who signs what
 
 | Transaction | Who signs |
 |-------------|-----------|
-| `creationTransaction` | fee payer or sponsor path |
-| `addAuthorityTransaction` | current wallet authority |
-| `configureRecoveryTransaction` | backend recovery operator already signs it |
+| `creationTransaction` / `creation_transaction` | fee payer or sponsor path |
+| `addAuthorityTransaction` / `add_authority_transaction` | current wallet authority |
+| `configureRecoveryTransaction` / `configure_recovery_transaction` | backend recovery operator already signs it |
 
-Do not authority-sign `operatorSignedTransactions` again.
+Do not authority-sign `operatorSignedTransactions` /
+`operator_signed_transactions` again.
 
 ## Advanced option
 
-`targetRoleId` is available when you intentionally want recovery bound to a
-specific non-default role.
+`targetRoleId` / `target_role_id` is available when you intentionally want
+recovery bound to a specific non-default role.

--- a/developer-sdk/server-and-client.mdx
+++ b/developer-sdk/server-and-client.mdx
@@ -26,9 +26,17 @@ The server owns:
 
 The main entrypoint is:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 import { SwigClient } from '@swig-wallet/developer-sdk/server/typescript';
 ```
+
+```python Python
+from swig_developer_sdk import SwigClient
+```
+
+</CodeGroup>
 
 ## What reaches the client
 
@@ -40,23 +48,27 @@ directly.
 
 Prepared responses are categorized so your app knows what to do next:
 
-| Field | What your app should do |
+| TypeScript / Python | What your app should do |
 |-------|-------------------------|
 | `transactions` | submit these in order |
-| `clientAuthorityTransactions` | get a client authority signature first |
-| `feePayerOnlyTransactions` | send or sponsor without client authority signing |
-| `operatorSignedTransactions` | submit as-is after fee payer or sponsor handling |
+| `clientAuthorityTransactions` / `client_authority_transactions` | get a client authority signature first |
+| `feePayerOnlyTransactions` / `fee_payer_only_transactions` | send or sponsor without client authority signing |
+| `operatorSignedTransactions` / `operator_signed_transactions` | submit as-is after fee payer or sponsor handling |
 
 For recovery-enabled wallet creation, `create(...)` also returns
-`creationTransaction`, `addAuthorityTransaction`, `configureRecoveryTransaction`,
-and sometimes `recoverySetup`.
+`creationTransaction` / `creation_transaction`, `addAuthorityTransaction` /
+`add_authority_transaction`, `configureRecoveryTransaction` /
+`configure_recovery_transaction`, and sometimes `recoverySetup` /
+`recovery_setup`.
 
 ## Wallet handles
 
 The server-side wallet handle is how you move from "I know this wallet" to "I
 want to prepare actions for it":
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const wallet = swig.wallets.use({
   swigConfigAddress,
   walletAddress,
@@ -68,6 +80,19 @@ const wallet = swig.wallets.use({
 });
 ```
 
+```python Python
+wallet = swig.wallets.use(
+    swig_config_address,
+    requester_authority={
+        "ed25519": {
+            "publicKey": user_public_key,
+        },
+    },
+)
+```
+
+</CodeGroup>
+
 If you already have an IDP session, the SDK also supports
 `swig.wallets.fromIdpSession(session)`.
 
@@ -75,10 +100,12 @@ If you already have an IDP session, the SDK also supports
 
 The client package is intentionally small:
 
-- `signPreparedTransaction(...)` for normal Ed25519 transaction signing
-- `signPreparedSwigTransaction(...)` and
-  `signPreparedSwigTransactions(...)` for passkey-backed Swig signature flows
-- passkey signing helpers such as `createSecp256r1PasskeySigningFn(...)`
+- `signPreparedTransaction(...)` / `sign_prepared_transaction(...)` for normal
+  Ed25519 transaction signing
+- `signPreparedSwigTransaction(...)` / `sign_prepared_swig_transaction(...)`
+  for passkey-backed Swig signature flows
+- passkey signing helpers such as `createSecp256r1PasskeySigningFn(...)` /
+  `create_secp256r1_passkey_signing_fn(...)`
 
 Use the browser and framework pages next if you want this split without writing
 all of the proxy glue yourself.

--- a/developer-sdk/sponsor-and-submit.mdx
+++ b/developer-sdk/sponsor-and-submit.mdx
@@ -14,13 +14,29 @@ them. There are two models:
 Use `swig.transactions.sponsor(...)` when your server should hand the signed
 transaction to Swig's sponsor path:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 await swig.transactions.sponsor({
   transaction: signed.transaction,
   transactionEncoding: signed.transactionEncoding,
   network: signed.network,
 });
 ```
+
+```python Python
+from swig_developer_sdk import SponsorSignedTransactionArgs
+
+await swig.transactions.sponsor(
+    SponsorSignedTransactionArgs(
+        transaction=signed.transaction,
+        transaction_encoding=signed.transaction_encoding,
+        network=signed.network,
+    )
+)
+```
+
+</CodeGroup>
 
 The client still signs first when authority signatures are required. Sponsoring
 does not replace client authority signing.
@@ -37,10 +53,12 @@ Use it when:
 
 These categories tell you what can go straight to send or sponsor:
 
-- `clientAuthorityTransactions` must be client-signed first
-- `feePayerOnlyTransactions` can go straight to your fee payer or sponsor path
-- `operatorSignedTransactions` are already operator-signed and just need final
-  submission handling
+- `clientAuthorityTransactions` / `client_authority_transactions` must be
+  client-signed first
+- `feePayerOnlyTransactions` / `fee_payer_only_transactions` can go straight
+  to your fee payer or sponsor path
+- `operatorSignedTransactions` / `operator_signed_transactions` are already
+  operator-signed and just need final submission handling
 
 ## Portal admin vs runtime usage
 

--- a/developer-sdk/swaps-and-batches.mdx
+++ b/developer-sdk/swaps-and-batches.mdx
@@ -7,7 +7,9 @@ Use the built-in helpers when your app needs more than one simple transfer.
 
 ## Jupiter swaps
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const preparedSwap = await wallet.swap.jupiter({
   feePayer,
   inputMint,
@@ -19,6 +21,20 @@ const preparedSwap = await wallet.swap.jupiter({
 });
 ```
 
+```python Python
+prepared_swap = await wallet.swap.jupiter(
+    fee_payer=fee_payer,
+    input_mint=input_mint,
+    output_mint=output_mint,
+    amount=10_000,
+    slippage_bps=100,
+    destination_account=destination_account,
+    wrap_and_unwrap_sol=True,
+)
+```
+
+</CodeGroup>
+
 `destinationAccount` is the recipient owner. The backend resolves the output
 ATA for SPL outputs or the native destination for unwrapped SOL.
 
@@ -27,7 +43,9 @@ ATA for SPL outputs or the native destination for unwrapped SOL.
 Use `wallet.prepare(...)` when you want the backend to shape a batch instead of
 calling single-operation helpers one by one.
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const prepared = await wallet.prepare({
   feePayer,
   operations: [
@@ -45,6 +63,27 @@ const prepared = await wallet.prepare({
   ],
 });
 ```
+
+```python Python
+from swig_developer_sdk import TransferSolOperation, TransferTokenOperation
+
+prepared = await wallet.prepare(
+    fee_payer=fee_payer,
+    operations=(
+        TransferSolOperation(
+            destination=destination,
+            amount=1_000_000,
+        ),
+        TransferTokenOperation(
+            mint=mint,
+            destination_owner=destination_owner,
+            amount=10_000,
+        ),
+    ),
+)
+```
+
+</CodeGroup>
 
 ## When to use this page
 

--- a/developer-sdk/transfers-swaps-and-signing.mdx
+++ b/developer-sdk/transfers-swaps-and-signing.mdx
@@ -10,7 +10,9 @@ Most app flows start with a wallet handle, then prepare one movement at a time.
 Attach to an existing wallet with the config address, wallet address, and the
 authority that should sign on the client:
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const wallet = swig.wallets.use({
   swigConfigAddress,
   walletAddress,
@@ -22,6 +24,19 @@ const wallet = swig.wallets.use({
 });
 ```
 
+```python Python
+wallet = swig.wallets.use(
+    swig_config_address,
+    requester_authority={
+        "ed25519": {
+            "publicKey": user_public_key,
+        },
+    },
+)
+```
+
+</CodeGroup>
+
 The same handle shape works for `secp256k1` and `secp256r1` authorities too.
 
 If you already have an IDP session, the same model works through
@@ -29,7 +44,9 @@ If you already have an IDP session, the same model works through
 
 ## SOL transfer
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const preparedTransfer = await wallet.transfer.sol({
   feePayer,
   destination,
@@ -37,12 +54,24 @@ const preparedTransfer = await wallet.transfer.sol({
 });
 ```
 
+```python Python
+prepared_transfer = await wallet.transfer.sol(
+    fee_payer=fee_payer,
+    destination=destination,
+    amount=1_000_000,
+)
+```
+
+</CodeGroup>
+
 ## Token transfer
 
 Token transfers are owner-based. The backend derives the token program, source
 ATA, destination ATA, and any destination ATA creation it needs.
 
-```typescript
+<CodeGroup dropdown>
+
+```typescript TypeScript
 const preparedTokenTransfer = await wallet.transfer.token({
   feePayer,
   mint,
@@ -51,16 +80,27 @@ const preparedTokenTransfer = await wallet.transfer.token({
 });
 ```
 
+```python Python
+prepared_token_transfer = await wallet.transfer.token(
+    fee_payer=fee_payer,
+    mint=mint,
+    destination_owner=destination_owner,
+    amount=10_000,
+)
+```
+
+</CodeGroup>
+
 ## How to read the result
 
 Prepared results are intentionally split:
 
-| Field | Meaning |
+| TypeScript / Python | Meaning |
 |-------|---------|
 | `transactions` | ordered transactions to submit |
-| `clientAuthorityTransactions` | transactions that still need client authority |
-| `feePayerOnlyTransactions` | transactions that only need fee payer or sponsor submission |
-| `signatureRequests` | per-transaction signature metadata |
+| `clientAuthorityTransactions` / `client_authority_transactions` | transactions that still need client authority |
+| `feePayerOnlyTransactions` / `fee_payer_only_transactions` | transactions that only need fee payer or sponsor submission |
+| `signatureRequests` / `signature_requests` | per-transaction signature metadata |
 
 ## Submission
 

--- a/docs.json
+++ b/docs.json
@@ -170,7 +170,7 @@
       {
         "product": "Developer SDK",
         "icon": "building",
-        "description": "Prepare wallet creation, transfers, swaps, recovery, and sponsored submission on your server",
+        "description": "Prepare wallet creation, transfers, swaps, recovery, and sponsored submission with TypeScript or Python",
         "groups": [
           {
             "group": "Start Here",

--- a/overview/developer-sdk.mdx
+++ b/overview/developer-sdk.mdx
@@ -4,7 +4,8 @@ sidebarTitle: "Developer SDK"
 ---
 
 Use the Developer SDK section when your backend keeps the API key and prepares
-wallet actions for the client to sign.
+wallet actions for the client to sign. The hosted server SDK is available for
+TypeScript and Python.
 
 Start there for:
 


### PR DESCRIPTION
## Summary

- add a TypeScript/Python language chooser to the Developer SDK landing page
- add synchronized language dropdowns across shared wallet, signing, transfer, swap, recovery, custom execution, and paymaster examples
- document the Python proxy handler while keeping browser-only TypeScript surfaces explicit
- show TypeScript camelCase and Python snake_case response fields together

## Verification

- `jq empty docs.json`
- `git diff --check`
- Mintlify local preview rendered with zero browser console errors
- switched the landing page from TypeScript to Python
- switched one create-wallet dropdown to Python and verified all create examples synchronized
- `mintlify broken-links` reports only the existing `examples/passkeys.mdx -> secp256r1_authority` link; this PR does not change that file
