### PR TITLE
docs(developer-sdk): document 0.7 transaction preparation

### DIFF
--- a/developer-api/transactions.mdx
+++ b/developer-api/transactions.mdx
@@ -39,9 +39,10 @@ transactions.
 | `kind` | enum | Prepared transaction category |
 | `signatureRequests` | array | Client authority signatures required before submission |
 
-## Prepare operations
+## Prepare a batch
 
-`POST /transaction/prepare` batches one or more operations for an existing Swig.
+`POST /transaction/prepare/batch` batches one or more supported operations for
+an existing Swig.
 
 ```json
 {
@@ -61,6 +62,38 @@ transactions.
   ]
 }
 ```
+
+## Prepare custom instructions
+
+`POST /transaction/prepare/custom` builds one prepared Swig transaction from
+the Solana instructions supplied by the application.
+
+```json
+{
+  "network": "NETWORK_DEVNET",
+  "feePayer": "FeePayerPublicKey",
+  "swigAddress": "SwigConfigAddress",
+  "requesterAuthority": {
+    "ed25519": { "publicKey": "RequesterPublicKey" }
+  },
+  "instructions": [
+    {
+      "programId": "ProgramPublicKey",
+      "accounts": [
+        {
+          "pubkey": "WritableAccountPublicKey",
+          "isWritable": true
+        }
+      ],
+      "data": "Base64EncodedInstructionData"
+    }
+  ],
+  "addressLookupTableAccounts": ["LookupTablePublicKey"]
+}
+```
+
+The response is prepared only. The application still supplies any requested
+client authority signature and chooses direct or sponsored submission.
 
 ## Create a wallet
 

--- a/developer-sdk/custom-execution.mdx
+++ b/developer-sdk/custom-execution.mdx
@@ -1,15 +1,16 @@
 ---
-title: "Run Custom Instructions"
-sidebarTitle: "Custom Execution"
+title: "Build Custom Transactions"
+sidebarTitle: "Custom Transactions"
 ---
 
-The built-in helpers cover common flows. `wallet.execute(...)` is the escape
-hatch when you still want hosted preparation but need your own instruction set.
+The built-in helpers cover common flows. Use `wallet.buildTransaction(...)` or
+`wallet.build_transaction(...)` when you still want hosted preparation but need
+your own instruction set.
 
 ## What it does
 
-`wallet.execute(...)` prepares a transaction for an existing Swig wallet from a
-list of Solana instructions you provide.
+The custom transaction builder prepares a transaction for an existing Swig
+wallet from a list of Solana instructions you provide.
 
 Use it when:
 
@@ -22,7 +23,8 @@ Use it when:
 <CodeGroup dropdown>
 
 ```typescript TypeScript
-const prepared = await wallet.execute({
+const prepared = await wallet.buildTransaction({
+  feePayer,
   instructions: [
     {
       programId: targetProgramId,
@@ -45,7 +47,8 @@ const prepared = await wallet.execute({
 ```python Python
 from swig_developer_sdk import SolanaAccountMeta, SolanaInstructionInput
 
-prepared = await wallet.execute(
+prepared = await wallet.build_transaction(
+    fee_payer=fee_payer,
     instructions=(
         SolanaInstructionInput(
             program_id=target_program_id,
@@ -65,8 +68,9 @@ prepared = await wallet.execute(
 
 </CodeGroup>
 
-The SDK normalizes the instruction input and sends it to the hosted execute
-endpoint for preparation.
+The SDK normalizes the instruction input and sends it to
+`POST /transaction/prepare/custom`. The API prepares the transaction; it does
+not submit it or insert the client authority signature.
 
 ## What still applies
 

--- a/developer-sdk/index.mdx
+++ b/developer-sdk/index.mdx
@@ -40,7 +40,7 @@ With this SDK, you can:
 
 - create wallets from a backend route
 - prepare transfers, swaps, and grouped wallet operations
-- run custom instruction execution against an existing wallet
+- build a transaction from custom instructions for an existing wallet
 - add guardian-based recovery flows
 - submit signed transactions through Swig's sponsor path
 - expose all of that through Next.js, NestJS, a Python proxy handler, or your

--- a/developer-sdk/portal-clients.mdx
+++ b/developer-sdk/portal-clients.mdx
@@ -10,7 +10,7 @@ They overlap, but they are not the same product.
 
 | Package | Status | Best use | Policy access | Transaction access | Response model |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| `@swig-wallet/developer-sdk` | current | prepare-first hosted wallet flows | `swig.wallets.getPolicy()` returns raw policy metadata | wallet creation, transfers, swaps, custom execution, recovery, sponsor flow | prepared transactions and signing metadata |
+| `@swig-wallet/developer-sdk` | current | prepare-first hosted wallet flows | `swig.wallets.getPolicy()` returns raw policy metadata | wallet creation, transfers, swaps, custom transaction preparation, recovery, sponsor flow | prepared transactions and signing metadata |
 | `@swig-wallet/developer` | legacy | existing portal integrations that depend on rich helper models | `client.getPolicy()` returns `Policy`, `Actions`, and `AuthorityInfo` helpers | `createWallet()` only | throws `SwigError` |
 | `@swig-wallet/api` | low-level | direct portal and paymaster endpoint access | `client.policies.get()` returns raw policy JSON | raw portal and paymaster calls | returns `{ data, error }` |
 

--- a/developer-sdk/swaps-and-batches.mdx
+++ b/developer-sdk/swaps-and-batches.mdx
@@ -41,7 +41,8 @@ ATA for SPL outputs or the native destination for unwrapped SOL.
 ## Grouped operations
 
 Use `wallet.prepare(...)` when you want the backend to shape a batch instead of
-calling single-operation helpers one by one.
+calling single-operation helpers one by one. Both SDKs send this request to
+`POST /transaction/prepare/batch`.
 
 <CodeGroup dropdown>
 

--- a/examples/passkeys.mdx
+++ b/examples/passkeys.mdx
@@ -511,5 +511,5 @@ Check out these working implementations:
 
 ## Resources
 
-- [Swig secp256r1 Authority Documentation](secp256r1_authority)
+- [Swig secp256r1 Authority Documentation](/examples/secp256r1_authority)
 - [Swig Passkey UI Example](https://github.com/anagrambuild/swig-ts/tree/main/examples/secp-ui) - Interactive UI implementation with passkey helpers


### PR DESCRIPTION
## Summary
- replace stale `wallet.execute` examples with `wallet.buildTransaction` and Python `wallet.build_transaction`
- document `/transaction/prepare/batch` and `/transaction/prepare/custom` request shapes
- clarify that custom preparation does not submit or insert client signatures
- fix the existing secp256r1 docs link found by validation

## Validation
- `mint validate` (Mintlify CLI 4.2.502, Node 22)
- `mint broken-links`
- `git diff --check`