### PR TITLE
docs: use affirmative product guidance

### DIFF
--- a/developer-api/authentication.mdx
+++ b/developer-api/authentication.mdx
@@ -25,10 +25,11 @@ Send your API key as a bearer token:
 Authorization: Bearer sk_your_api_key
 ```
 
-Runtime API keys are created in the Developer Portal and should stay on your
-server. Do not expose an API key in browser or mobile client code.
+Runtime API keys are created in the Developer Portal. Keep them on your server
+and send browser or mobile requests through your backend.
 
-This section intentionally excludes developer-portal admin endpoints.
+This section covers runtime product APIs. Use the Developer Portal for
+administrative operations.
 
 ## JSON encoding
 

--- a/developer-api/errors.mdx
+++ b/developer-api/errors.mdx
@@ -47,8 +47,9 @@ Some legacy endpoints or SDK proxy routes may return an object-shaped error:
 ## Client handling
 
 - Retry `429` and transient `5xx` responses with exponential backoff.
-- Do not retry validation failures without changing the request.
+- Retry validation failures only after changing the request.
 - Treat `401` as an API-key or credential configuration failure.
 - Treat `403` as an organization/resource access failure.
-- Log request ids and non-sensitive identifiers, but do not log API keys,
-  signed transactions, launch URLs, OTP values, or upstream provider payloads.
+- Log only request ids and non-sensitive identifiers. Keep API keys, signed
+  transactions, launch URLs, OTP values, and upstream provider payloads out of
+  logs.

--- a/developer-sdk/create-wallets.mdx
+++ b/developer-sdk/create-wallets.mdx
@@ -128,7 +128,7 @@ follow-up input for `wallet.recovery.prepareSetup(...)` /
 
 ## What to submit
 
-Always submit the prepared `transactions` in order. Do not reorder the list.
+Always submit the prepared `transactions` exactly in the returned order.
 
 If the client-authority transaction collection is not empty, those transactions
 must be signed by the client authority before submission.

--- a/developer-sdk/custom-execution.mdx
+++ b/developer-sdk/custom-execution.mdx
@@ -69,8 +69,8 @@ prepared = await wallet.build_transaction(
 </CodeGroup>
 
 The SDK normalizes the instruction input and sends it to
-`POST /transaction/prepare/custom`. The API prepares the transaction; it does
-not submit it or insert the client authority signature.
+`POST /transaction/prepare/custom`. The API returns the prepared transaction
+for your client-signing and submission flow.
 
 ## What still applies
 
@@ -80,8 +80,7 @@ This is still a prepared transaction result. That means:
 - the client still signs if required
 - your app still chooses direct submission or sponsor submission
 
-## When not to use it
+## Full protocol control
 
-If you want full protocol control, custom role or action construction, or
-instruction-by-instruction authoring without the hosted backend, use the
-[Protocol SDK](/reference) instead.
+Use the [Protocol SDK](/reference) for full protocol control, custom role or
+action construction, or instruction-by-instruction authoring.

--- a/developer-sdk/framework-proxies.mdx
+++ b/developer-sdk/framework-proxies.mdx
@@ -9,7 +9,7 @@ the SDK already ships it.
 ## Use this path when
 
 - you want the API key to stay on the server
-- you do not want to wire each prepare route by hand
+- you want the SDK to wire the prepare routes
 - you still want browser code to work with wallet handles and prepared results
 
 ## Next.js

--- a/developer-sdk/index.mdx
+++ b/developer-sdk/index.mdx
@@ -59,12 +59,14 @@ With this SDK, you can:
 - use a built-in TypeScript framework helper or the Python proxy handler
 - use the browser client against your own proxy routes
 
-## What it is not
+## Choose the matching SDK surface
 
-- It is not the direct protocol SDK. Use `@swig-wallet/classic`,
-  `@swig-wallet/kit`, or `swig-sdk` when you want direct protocol integration.
-- It is not a browser-direct API client. The API key belongs on the server.
-- It is not the richer legacy policy-helper client in `@swig-wallet/developer`.
+- Use `@swig-wallet/developer-sdk` for hosted wallet preparation and keep its
+  API key on the server.
+- Use `@swig-wallet/classic`, `@swig-wallet/kit`, or `swig-sdk` for direct
+  protocol integration.
+- Keep existing `@swig-wallet/developer` integrations when they depend on its
+  legacy policy helpers.
 
 ## Where to go next
 

--- a/developer-sdk/integration-paths.mdx
+++ b/developer-sdk/integration-paths.mdx
@@ -26,8 +26,8 @@ from swig_developer_sdk import SwigClient
 
 ## 2. Proxy helpers
 
-Use the framework helpers when you want the API key to stay on the server, but
-you do not want to implement each prepare route yourself.
+Use the framework helpers when you want the API key to stay on the server and
+the SDK to implement the prepare routes.
 
 Main entrypoints:
 

--- a/developer-sdk/portal-clients.mdx
+++ b/developer-sdk/portal-clients.mdx
@@ -14,7 +14,7 @@ They overlap, but they are not the same product.
 | `@swig-wallet/developer` | legacy | existing portal integrations that depend on rich helper models | `client.getPolicy()` returns `Policy`, `Actions`, and `AuthorityInfo` helpers | `createWallet()` only | throws `SwigError` |
 | `@swig-wallet/api` | low-level | direct portal and paymaster endpoint access | `client.policies.get()` returns raw policy JSON | raw portal and paymaster calls | returns `{ data, error }` |
 
-## Start here unless you have a reason not to
+## Recommended starting point
 
 Use `@swig-wallet/developer-sdk` first if your goal is to:
 

--- a/developer-sdk/recovery-setup.mdx
+++ b/developer-sdk/recovery-setup.mdx
@@ -105,8 +105,8 @@ That returns:
 | `addAuthorityTransaction` / `add_authority_transaction` | current wallet authority |
 | `configureRecoveryTransaction` / `configure_recovery_transaction` | backend recovery operator already signs it |
 
-Do not authority-sign `operatorSignedTransactions` /
-`operator_signed_transactions` again.
+Treat `operatorSignedTransactions` / `operator_signed_transactions` as already
+authority-signed and submit them through the fee payer or sponsor path.
 
 ## Advanced option
 

--- a/examples/dev-portal/create-swig.mdx
+++ b/examples/dev-portal/create-swig.mdx
@@ -125,7 +125,9 @@ If you've already created a signer in the Developer Portal dashboard (or your po
 You can supply a `walletAddress` (the public key) and `walletType` (the authority type) at creation time instead of using a signer ID. This lets you skip creating a signer in the dashboard entirely -- useful when your application already knows the user's public key and authority type.
 
 <Info>
-  You must use one approach or the other -- provide either `signerId` **or** the `walletAddress` + `walletType` pair. If your policy already has a signer attached and you don't pass either, the policy's signer is used by default.
+  Provide either `signerId` **or** the `walletAddress` + `walletType` pair. When
+  your policy already has a signer attached and both inputs are omitted, the
+  policy's signer is used by default.
 </Info>
 
 ### Supported Wallet Types
@@ -395,7 +397,7 @@ When you omit `paymasterPubkey`, the API builds the create-swig transaction but 
 This is useful when:
 - Your users pay their own transaction fees
 - You want to collect multiple signatures before sending
-- You don't want to set up or fund a paymaster
+- You prefer to manage fee payment directly
 
 ### Using the REST API (No Paymaster)
 

--- a/examples/dev-portal/manage-members.mdx
+++ b/examples/dev-portal/manage-members.mdx
@@ -249,7 +249,7 @@ Possible causes:
 
 Possible causes:
 - The member is the last owner
-- You don't have sufficient permissions
+- Your role lacks sufficient permissions
 
 ## Next Steps
 

--- a/examples/dev-portal/paymaster-overview.mdx
+++ b/examples/dev-portal/paymaster-overview.mdx
@@ -3,7 +3,8 @@ title: "Paymaster"
 sidebarTitle: "Paymaster"
 ---
 
-Paymasters enable gasless transactions by sponsoring transaction fees on behalf of your users. This creates a seamless user experience where users don't need SOL to interact with your application.
+Paymasters enable gasless transactions by sponsoring transaction fees on behalf
+of your users, so they can begin using your application before acquiring SOL.
 
 ## What is a Paymaster?
 
@@ -75,7 +76,7 @@ Each paymaster needs SOL to sponsor transactions:
 ### User Onboarding
 
 Remove friction for new users:
-- Users don't need to acquire SOL first
+- Users can begin transacting immediately
 - Immediate access to your application
 - Higher conversion rates
 

--- a/examples/dev-portal/subscriptions-billing.mdx
+++ b/examples/dev-portal/subscriptions-billing.mdx
@@ -170,7 +170,7 @@ Enterprise subscriptions can be:
 
 - Billed on the same day each month
 - Usage tracked from period start to end
-- Unused limits don't roll over
+- Limits reset at the start of each billing period
 
 ### Period Reset
 

--- a/examples/paymaster/index.mdx
+++ b/examples/paymaster/index.mdx
@@ -6,10 +6,11 @@ This guide covers how to use the Swig Paymaster SDK to sponsor transaction fees 
 
 ## What is a Paymaster?
 
-A paymaster is a service that pays transaction fees on behalf of users. Instead of requiring users to hold SOL for gas fees, the paymaster covers these costs, creating a seamless onboarding experience.
+A paymaster is a service that pays transaction fees on behalf of users, so they
+can begin using your application before acquiring SOL.
 
 **Benefits:**
-- Users don't need SOL for transaction fees
+- Users can transact before acquiring SOL
 - Lower barrier to entry for new users
 - Better user experience for dApps
 

--- a/examples/paymaster/sponsor-transactions.mdx
+++ b/examples/paymaster/sponsor-transactions.mdx
@@ -20,7 +20,8 @@ The paymaster client provides several methods for working with transactions:
 
 ### Legacy Transactions (Classic Only)
 
-Legacy transactions are simpler but don't support address lookup tables:
+Use legacy transactions for fixed account lists and versioned transactions for
+address lookup table support:
 
 ```typescript
 import { Keypair, PublicKey, SystemProgram } from '@solana/web3.js';

--- a/examples/sub_accounts.mdx
+++ b/examples/sub_accounts.mdx
@@ -10,9 +10,15 @@ You can find complete working examples in the Swig repository:
 
 ## What are Sub Accounts?
 
-Sub accounts in Swig allow an authority to create and manage a single sub account address and perform any actions on behalf of that sub account. This is a super high level of permission so use with care. It works for use cases like portfolio management, where you want to allow an unlimited complexity of actions on behalf of a single address, but you don't want to give the authority control over all the assets of the swig. The root authority can always pull funds (SOL and tokens) from the sub account back to the main Swig wallet.
+Sub accounts in Swig allow an authority to create and manage a dedicated
+address and perform any actions on its behalf. This broad permission fits use
+cases like portfolio management, where the authority can perform complex
+actions while remaining scoped to the sub account's assets. The root authority
+can always pull SOL and tokens from the sub account back to the main Swig wallet.
 
-A great example of this is Breeze, Anagram's onchain yield optimizer. Breeze can optimize the yield of a user's portfolio without giving them control over their whole swig.
+A great example of this is Breeze, Anagram's onchain yield optimizer. Breeze can
+optimize the yield of a user's portfolio while its authority remains scoped to
+the sub account.
 
 ## How Sub Accounts Work
 

--- a/examples/swap.mdx
+++ b/examples/swap.mdx
@@ -125,7 +125,8 @@ console.log('Swig wallet address:', swigWalletAddress.toBase58());
 
 ### 2. Setting Up Token Accounts
 <Note>
-This isnt technically necessary, but we leave it here for your benefit. Jupiter will create the token accounts for you if they don't exist in the setup instructions that are returned from the Jupiter API.
+Jupiter's returned setup instructions create any missing token accounts. The
+explicit setup below is useful when you want to create and inspect them first.
 </Note>
 
 Before swapping, we need to ensure the Swig wallet has the necessary token accounts (both USDC and Wrapped SOL):
@@ -348,4 +349,3 @@ The example will:
 For more information, check out:
 - [Jupiter API Documentation](https://station.jup.ag/docs/apis/overview)
 - [Swig Documentation](https://docs.swig.rs/)
-

--- a/idp-sdk/expo-and-react-native.mdx
+++ b/idp-sdk/expo-and-react-native.mdx
@@ -72,7 +72,7 @@ export function App() {
 - session persistence defaults to `expo-secure-store`
 - the default network is devnet unless you override `network`
 
-## What to avoid
+## Supported mobile boundary
 
-Do not embed the isolated host in a `WebView`. The supported mobile path is a
-system auth session so the host app cannot inspect the auth page.
+Open the isolated host through a system auth session. This keeps the auth page
+outside the host app's inspection boundary.

--- a/idp-sdk/index.mdx
+++ b/idp-sdk/index.mdx
@@ -18,15 +18,12 @@ It lives in `swig-idp-sdk` and currently ships as
 - isolated-host redirects that return a Swig session
 - handing that session off to wallet or policy flows afterward
 
-## What this SDK is not for
+## Continue into the Swig stack
 
-- transaction preparation
-- paymaster operations
-- policy management in the developer portal
-- direct protocol instruction building
-
-Use [Developer SDK](/developer-sdk) for hosted wallet operations after login,
-or [Protocol SDK](/reference) for direct protocol integration.
+- Use [Developer SDK](/developer-sdk) for hosted wallet preparation and
+  paymaster operations after login.
+- Use the Developer Portal for policy management.
+- Use [Protocol SDK](/reference) for direct protocol instruction building.
 
 ## Choose your path
 

--- a/protocol/index.mdx
+++ b/protocol/index.mdx
@@ -61,7 +61,6 @@ Use the rest of the Protocol section in this order:
 ## Where `swig-wallet` fits
 
 The `swig-wallet` workspace includes the Solana program plus the protocol-facing
-Rust crates, instruction builders, state types, assertions, and CLI. If you are
-working above this layer, you usually do not need to understand every Rust
-module. You do need to understand the account model, `role_id`, and the
-execution rules.
+Rust crates, instruction builders, state types, assertions, and CLI. Higher-level
+SDK surfaces abstract the individual Rust modules. Direct integrations should
+focus on the account model, `role_id`, and execution rules.

--- a/protocol/sessions-and-subaccounts.mdx
+++ b/protocol/sessions-and-subaccounts.mdx
@@ -31,7 +31,7 @@ The protocol has session-capable variants for:
 - Secp256r1
 - ProgramExec
 
-Sessions do not create a new permission model. They reuse the same role and
+Sessions keep the existing permission model. They reuse the same role and
 action set with temporary authentication material.
 
 ## When to use sessions
@@ -42,7 +42,8 @@ Use sessions when you want:
 - shorter-lived credentials
 - reduced need to re-present the base authority on every action
 
-Do not use sessions as a substitute for designing the right role and action set.
+Design the role and action set first, then use sessions as temporary
+authentication material for that permission model.
 
 ## How sub-accounts work
 
@@ -82,8 +83,7 @@ Use sub-accounts when you want:
 - the ability to disable a role's balance bucket without changing the whole
   wallet
 
-## Common integration mistake
+## Relationship to the parent wallet
 
-Do not treat a sub-account as an unrelated external account. It is still part
-of the parent wallet's role model, and its validity depends on the stored
-`SubAccount` action metadata.
+A sub-account remains part of the parent wallet's role model, and its validity
+depends on the stored `SubAccount` action metadata.

--- a/reference/index.mdx
+++ b/reference/index.mdx
@@ -40,7 +40,7 @@ and protocol access directly.
 - Use the TypeScript or Rust package sections if you already know your stack.
 - Use examples and recipes if you want working end-to-end patterns.
 
-## What this section does not cover
+## Hosted integrations
 
-This section does not cover the hosted, API-key-based
-[Developer SDK](/developer-sdk).
+Use the API-key-based [Developer SDK](/developer-sdk) for hosted wallet
+preparation and sponsorship flows.

--- a/tutorials/typescript/managing_authorities.mdx
+++ b/tutorials/typescript/managing_authorities.mdx
@@ -480,7 +480,7 @@ This creates a Swig account where the root authority has permission to manage ot
 
 ### 2. Adding a SOL Spending Authority
 
-Don't forget that the full list of actions an authority can have is [here](https://anagrambuild.github.io/swig-ts/enums/_swig-wallet_coder.Permission.html).
+See the [full list of actions an authority can have](https://anagrambuild.github.io/swig-ts/enums/_swig-wallet_coder.Permission.html).
 
 <Tabs>
   <Tab title="Classic">


### PR DESCRIPTION
## Summary
- replace exclusion-first headings with capability and routing guidance
- phrase security and correctness requirements as required actions
- keep literal API errors and permission constraints unchanged

## Validation
- `mintlify validate` (Node 22)
- `mintlify broken-links` (Node 22)
- `git diff --check`